### PR TITLE
feat: headless CARLA+SHARC experiment runner

### DIFF
--- a/README.carla-sharc.md
+++ b/README.carla-sharc.md
@@ -24,13 +24,12 @@ A combined Docker environment with CARLA 0.9.16 simulator and SHARC tools.
 newgrp docker
 
 # 1. Build the image (one time)
-# Use your host's UID/GID for full file access
 docker build \
     --build-arg USER_ID=$(id -u) \
     --build-arg GROUP_ID=$(id -g) \
     -f Dockerfile -t carla-sharc .
 
-# 2. Run the container
+# 2. Start the container
 ./run_carla_sharc.sh
 
 # 3. Inside container: start CARLA server
@@ -39,6 +38,42 @@ docker build \
 # 4. Run examples
 python /home/workspace/carla_0.9.16/PythonAPI/examples/automatic_control.py
 ```
+
+---
+
+## Headless Experiment Runner (no display required)
+
+Run a full CARLA + SHARC experiment from the **host machine** without a monitor.
+The script starts CARLA in headless mode (`-nullrhi`), waits for it to become
+ready, runs the SHARC experiment, and saves a dashboard PNG to the results folder.
+
+```bash
+# Default: MPC_example with obstacle_constraint.json
+./run_offscreen_experiment.sh
+
+# Specific example / config
+./run_offscreen_experiment.sh --example MPC_example --config obstacle_constraint.json
+
+# All options
+./run_offscreen_experiment.sh --help
+```
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--example NAME` | `MPC_example` | Example directory name |
+| `--config FILE` | `obstacle_constraint.json` | Simulation config filename |
+| `--container NAME` | `carla-sharc-yasin5` | Docker container name |
+| `--user NAME` | `admin` | Container user to run as |
+| `--timeout SECS` | `180` | CARLA startup timeout |
+| `--log FILE` | _(none)_ | Tee all output to a file on the host |
+
+**Output:** results are written to
+`examples/<EXAMPLE>/experiments/<timestamp>--<label>/`,
+including `experiment_data.json` and `dashboard_final.png`.
+
+**Prerequisites:** the container must already be running (`./run_carla_sharc.sh`).
 
 ---
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,5 +55,12 @@ fi
 # ── Fix ownership of the user's home directory ───────────────────────────────
 chown -R "$HOST_UID:$HOST_GID" "/home/$TARGET_USER" 2>/dev/null || true
 
+# ── Fix ownership of bind-mounted workspace dirs ─────────────────────────────
+# This repairs any root-owned files left by `docker exec` without -u, which
+# would otherwise block cmake/python processes running as the aligned user.
+for _dir in /home/workspace/sharc/examples /home/workspace/sharc/resources; do
+    [ -d "$_dir" ] && chown -R "$HOST_UID:$HOST_GID" "$_dir" 2>/dev/null || true
+done
+
 # ── Drop from root → TARGET_USER and exec the requested command ──────────────
 exec gosu "$TARGET_USER" "$@"

--- a/examples/MPC_example/CMakeLists.txt
+++ b/examples/MPC_example/CMakeLists.txt
@@ -8,6 +8,7 @@ set(TNX                 4 CACHE STRING "State Dimension")
 set(TNU                 2 CACHE STRING "Input Dimension")
 set(TNDU               20 CACHE STRING "Disturbance/Exogenous Input Dimension (2 * n_waypoints)")
 set(TNY                 2 CACHE STRING "Output Dimension")
+set(TNIEQ               0 CACHE STRING "Number of inequality constraints (Np*(n_obs+1) for constraint MPC)")
 set(USE_DYNAMORIO 1 CACHE BOOL OFF)
 
 # C++20
@@ -32,6 +33,7 @@ message("\tTNX=${TNX}")
 message("\tTNU=${TNU}")
 message("\tTNDU=${TNDU}")
 message("\tTNY=${TNY}")
+message("\tTNIEQ=${TNIEQ}")
 message("\tUSE_DYNAMORIO=${USE_DYNAMORIO}")
 
 # Assert environment variables
@@ -55,9 +57,11 @@ message("    CONTROLLERS_DIR=${CONTROLLERS_DIR}")
 message("    CONTROLLERS_INC=${CONTROLLERS_INC}")
 message("    CONTROLLERS_SRC=${CONTROLLERS_SRC}")
 
-# Source files
+# Source files — all MPC controllers + common controller infra
 set(SOURCES ${CONTROLLERS_SRC}/CarlaKinematicMPCController.cpp
             ${CONTROLLERS_SRC}/CarlaDynamicMPCController.cpp
+            ${CONTROLLERS_SRC}/CarlaObstacleMPCController.cpp
+            ${CONTROLLERS_SRC}/CarlaConstraintMPCController.cpp
             ${CONTROLLERS_SRC}/controller.cpp
             ${CONTROLLERS_SRC}/main_controller.cpp)
 
@@ -72,7 +76,7 @@ target_include_directories(
   /usr/local/include
   /usr/include/eigen3
   /usr/local/include/osqp
-  ${LIBMPC_DIR}/include/
+  ../libmpc/include/
   ${CONTROLLERS_INC}
   ${RESOURCES_DIR}/include
 )
@@ -104,6 +108,7 @@ add_definitions(
     -DTNU=${TNU}
     -DTNDU=${TNDU}
     -DTNY=${TNY}
+    -DTNIEQ=${TNIEQ}
     -O3
 )
 

--- a/examples/MPC_example/controller_delegator.py
+++ b/examples/MPC_example/controller_delegator.py
@@ -6,6 +6,7 @@ control horizon, and system dimensions to CMake.
 """
 
 import os
+import subprocess
 from sharc.controller_delegator_base import CmakeControllerExecutableProvider
 import sharc.debug_levels as debug_levels
 
@@ -24,6 +25,10 @@ class ControllerExecutableProvider(CmakeControllerExecutableProvider):
         exogenous_input_dimension = build_config["system_parameters"]["exogenous_input_dimension"]
         output_dimension          = build_config["system_parameters"]["output_dimension"]
 
+        mpc_opts     = build_config["system_parameters"].get("mpc_options", {})
+        n_obstacles  = mpc_opts.get("n_obstacles", 0)
+        n_ineq       = prediction_horizon * (n_obstacles + 1) if n_obstacles > 0 else 0
+
         executable_name = "main_controller_MPC_v1"
 
         # DynamoRIO is needed only for parallel mode with real delays.
@@ -40,6 +45,7 @@ class ControllerExecutableProvider(CmakeControllerExecutableProvider):
             f"-DTNU={input_dimension}",
             f"-DTNDU={exogenous_input_dimension}",
             f"-DTNY={output_dimension}",
+            f"-DTNIEQ={n_ineq}",
         ]
 
         if use_dynamorio:
@@ -49,6 +55,17 @@ class ControllerExecutableProvider(CmakeControllerExecutableProvider):
 
         if debug_levels.debug_build_level:
             print("== Running CMake to generate build tree ==")
+
+        # Ensure the build dir exists and is writable by the current user.
+        # If a previous `docker exec` (running as root) left root-owned files,
+        # use passwordless sudo to reclaim ownership before cmake runs.
+        os.makedirs(self.build_dir, exist_ok=True)
+        cmake_cache = os.path.join(self.build_dir, "CMakeCache.txt")
+        if os.path.exists(cmake_cache) and not os.access(cmake_cache, os.W_OK):
+            subprocess.run(
+                ["sudo", "chown", "-R", f"{os.getuid()}:{os.getgid()}", self.build_dir],
+                check=True,
+            )
 
         cmake_generate_tree_args = [
             "-S", f"{self.example_dir}",

--- a/examples/MPC_example/simulation_configs/obstacle_barrier.json
+++ b/examples/MPC_example/simulation_configs/obstacle_barrier.json
@@ -1,0 +1,77 @@
+{
+  "label": "obstacle_barrier",
+  "n_time_steps": 256,
+  "only_update_control_at_sample_times": true,
+  "delay_multiplier": 1,
+  "fake_delays": {
+    "enable": true,
+    "time_steps":              [],
+    "sample_time_multipliers": []
+  },
+  "x0": [0, 0, 0, 0],
+  "system_parameters": {
+    "state_dimension": 4,
+    "input_dimension": 2,
+    "exogenous_input_dimension": 65,
+    "output_dimension": 2,
+    "controller_type": "CarlaObstacleMPCController",
+    "x_names": ["px", "py", "psi", "v"],
+    "w_names": [
+      "wp_x_1","wp_y_1","wp_x_2","wp_y_2","wp_x_3","wp_y_3",
+      "wp_x_4","wp_y_4","wp_x_5","wp_y_5","wp_x_6","wp_y_6",
+      "wp_x_7","wp_y_7","wp_x_8","wp_y_8","wp_x_9","wp_y_9",
+      "wp_x_10","wp_y_10","wp_x_11","wp_y_11","wp_x_12","wp_y_12",
+      "wp_x_13","wp_y_13","wp_x_14","wp_y_14","wp_x_15","wp_y_15",
+      "wp_x_16","wp_y_16","wp_x_17","wp_y_17","wp_x_18","wp_y_18",
+      "wp_x_19","wp_y_19","wp_x_20","wp_y_20",
+      "obs1_x","obs1_y","obs1_vx","obs1_vy","obs1_r",
+      "obs2_x","obs2_y","obs2_vx","obs2_vy","obs2_r",
+      "obs3_x","obs3_y","obs3_vx","obs3_vy","obs3_r",
+      "obs4_x","obs4_y","obs4_vx","obs4_vy","obs4_r",
+      "obs5_x","obs5_y","obs5_vx","obs5_vy","obs5_r"
+    ],
+    "mpc_options": {
+      "prediction_horizon": 10,
+      "control_horizon": 10,
+      "wheelbase": 2.87,
+      "n_waypoints": 20,
+      "waypoint_spacing": 0.5,
+      "n_obstacles": 5,
+      "detection_radius": 30.0,
+      "cost_weights": {
+        "q_path":  1.0,
+        "q_speed": 1.0,
+        "r_accel": 1.0,
+        "r_steer": 10.0,
+        "r_jerk_v": 0.0,
+        "r_jerk_yaw": 0.0,
+        "gamma": 0.95,
+        "q_obs": 50.0,
+        "sigma_obs": 5.0,
+        "q_prog": 0.0,
+        "ego_radius": 2.5
+      },
+      "input_limits": {
+        "max_accel":  0.5,
+        "min_accel": -0.5,
+        "max_steer":  0.5,
+        "min_steer": -0.5
+      }
+    }
+  },
+  "carla": {
+    "seed": 30,
+    "npcs": {
+      "n_vehicles": 10,
+      "n_walkers":  0
+    }
+  },
+  "Simulation Options": {
+    "in-the-loop_delay_provider": "onestep",
+    "parallel_scarab_simulation": true,
+    "max_batches": 99
+  },
+  "PARAMS_patch_values": {
+    "chip_cycle_time": 500000
+  }
+}

--- a/examples/MPC_example/simulation_configs/obstacle_constraint.json
+++ b/examples/MPC_example/simulation_configs/obstacle_constraint.json
@@ -1,0 +1,80 @@
+{
+  "label": "obstacle_constraint",
+  "n_time_steps": 512,
+  "only_update_control_at_sample_times": true,
+  "delay_multiplier": 1,
+  "fake_delays": {
+    "enable": true,
+    "time_steps":              [],
+    "sample_time_multipliers": []
+  },
+  "x0": [0, 0, 0, 0],
+  "system_parameters": {
+    "state_dimension": 4,
+    "input_dimension": 2,
+    "exogenous_input_dimension": 95,
+    "output_dimension": 2,
+    "controller_type": "CarlaConstraintMPCController",
+    "x_names": ["px", "py", "psi", "v"],
+    "w_names": [
+      "wp_x_1","wp_y_1","wp_x_2","wp_y_2","wp_x_3","wp_y_3",
+      "wp_x_4","wp_y_4","wp_x_5","wp_y_5","wp_x_6","wp_y_6",
+      "wp_x_7","wp_y_7","wp_x_8","wp_y_8","wp_x_9","wp_y_9",
+      "wp_x_10","wp_y_10","wp_x_11","wp_y_11","wp_x_12","wp_y_12",
+      "wp_x_13","wp_y_13","wp_x_14","wp_y_14","wp_x_15","wp_y_15",
+      "wp_x_16","wp_y_16","wp_x_17","wp_y_17","wp_x_18","wp_y_18",
+      "wp_x_19","wp_y_19","wp_x_20","wp_y_20",
+      "wp_x_21","wp_y_21","wp_x_22","wp_y_22","wp_x_23","wp_y_23",
+        "wp_x_24","wp_y_24","wp_x_25","wp_y_25","wp_x_26","wp_y_26",
+        "wp_x_27","wp_y_27","wp_x_28","wp_y_28","wp_x_29","wp_y_29",
+        "wp_x_30","wp_y_30","wp_x_31","wp_y_31","wp_x_32","wp_y_32",
+        "wp_x_33","wp_y_33","wp_x_34","wp_y_34","wp_x_35","wp_y_35",
+        "wp_x_36","wp_y_36","wp_x_37","wp_y_37","wp_x_38","wp_y_38","wp_x_39","wp_y_39","wp_x_40","wp_y_40",
+      "obs1_x","obs1_y","obs1_vx","obs1_vy","obs1_r",
+      "obs2_x","obs2_y","obs2_vx","obs2_vy","obs2_r",
+      "obs3_x","obs3_y","obs3_vx","obs3_vy","obs3_r"
+    ],
+    "mpc_options": {
+      "prediction_horizon": 10,
+      "control_horizon": 10,
+      "wheelbase": 2.87,
+      "n_waypoints": 40,
+      "waypoint_spacing": 0.4,
+      "n_obstacles": 3,
+      "detection_radius": 30.0,
+      "cost_weights": {
+        "q_path":  1,
+        "q_speed": 1,
+        "r_accel": 1.0,
+        "r_steer": 10.0,
+        "r_jerk_v": 0.0,
+        "r_jerk_yaw": 0.0,
+        "gamma": 0.80,
+        "ego_radius": 2.5,
+        "safe_margin": 2.0,
+        "lane_half_width": 2.0
+      },
+      "input_limits": {
+        "max_accel":  0.75,
+        "min_accel": -3.0,
+        "max_steer":  0.5,
+        "min_steer": -0.5
+      }
+    }
+  },
+  "carla": {
+    "seed": 50,
+    "npcs": {
+      "n_vehicles": 10,
+      "n_walkers":  0
+    }
+  },
+  "Simulation Options": {
+    "in-the-loop_delay_provider": "onestep",
+    "parallel_scarab_simulation": true,
+    "max_batches": 99
+  },
+  "PARAMS_patch_values": {
+    "chip_cycle_time": 500000
+  }
+}

--- a/examples/MPC_example/simulation_configs/obstacle_progress.json
+++ b/examples/MPC_example/simulation_configs/obstacle_progress.json
@@ -1,0 +1,77 @@
+{
+  "label": "obstacle_progress",
+  "n_time_steps": 256,
+  "only_update_control_at_sample_times": true,
+  "delay_multiplier": 1,
+  "fake_delays": {
+    "enable": true,
+    "time_steps":              [],
+    "sample_time_multipliers": []
+  },
+  "x0": [0, 0, 0, 0],
+  "system_parameters": {
+    "state_dimension": 4,
+    "input_dimension": 2,
+    "exogenous_input_dimension": 65,
+    "output_dimension": 2,
+    "controller_type": "CarlaObstacleMPCController",
+    "x_names": ["px", "py", "psi", "v"],
+    "w_names": [
+      "wp_x_1","wp_y_1","wp_x_2","wp_y_2","wp_x_3","wp_y_3",
+      "wp_x_4","wp_y_4","wp_x_5","wp_y_5","wp_x_6","wp_y_6",
+      "wp_x_7","wp_y_7","wp_x_8","wp_y_8","wp_x_9","wp_y_9",
+      "wp_x_10","wp_y_10","wp_x_11","wp_y_11","wp_x_12","wp_y_12",
+      "wp_x_13","wp_y_13","wp_x_14","wp_y_14","wp_x_15","wp_y_15",
+      "wp_x_16","wp_y_16","wp_x_17","wp_y_17","wp_x_18","wp_y_18",
+      "wp_x_19","wp_y_19","wp_x_20","wp_y_20",
+      "obs1_x","obs1_y","obs1_vx","obs1_vy","obs1_r",
+      "obs2_x","obs2_y","obs2_vx","obs2_vy","obs2_r",
+      "obs3_x","obs3_y","obs3_vx","obs3_vy","obs3_r",
+      "obs4_x","obs4_y","obs4_vx","obs4_vy","obs4_r",
+      "obs5_x","obs5_y","obs5_vx","obs5_vy","obs5_r"
+    ],
+    "mpc_options": {
+      "prediction_horizon": 10,
+      "control_horizon": 10,
+      "wheelbase": 2.87,
+      "n_waypoints": 20,
+      "waypoint_spacing": 0.5,
+      "n_obstacles": 5,
+      "detection_radius": 30.0,
+      "cost_weights": {
+        "q_path":  1.0,
+        "q_speed": 1.0,
+        "r_accel": 1.0,
+        "r_steer": 10.0,
+        "r_jerk_v": 0.0,
+        "r_jerk_yaw": 0.0,
+        "gamma": 0.95,
+        "q_obs": 1000.0,
+        "sigma_obs": 1.0,
+        "q_prog": 5.0,
+        "ego_radius": 2.5
+      },
+      "input_limits": {
+        "max_accel":  0.5,
+        "min_accel": -0.5,
+        "max_steer":  0.5,
+        "min_steer": -0.5
+      }
+    }
+  },
+  "carla": {
+    "seed": 30,
+    "npcs": {
+      "n_vehicles": 10,
+      "n_walkers":  0
+    }
+  },
+  "Simulation Options": {
+    "in-the-loop_delay_provider": "onestep",
+    "parallel_scarab_simulation": true,
+    "max_batches": 99
+  },
+  "PARAMS_patch_values": {
+    "chip_cycle_time": 500000
+  }
+}

--- a/experiment_run.json
+++ b/experiment_run.json
@@ -1,0 +1,8 @@
+{
+    "example":        "MPC_example",
+    "config":         "obstacle_constraint.json",
+    "carla_root":     "/home/workspace/carla_0.9.16",
+    "sharc_examples": "/home/workspace/sharc/examples",
+    "timeout":        60,
+    "carla_args":     ""
+}

--- a/resources/controllers/include/CarlaConstraintMPCController.h
+++ b/resources/controllers/include/CarlaConstraintMPCController.h
@@ -1,0 +1,105 @@
+// controller/CarlaConstraintMPCController.h
+// Constraint-based obstacle-aware kinematic MPC controller.
+//
+// Instead of soft exponential barriers (Proposals E/F), uses HARD constraints:
+//   1. Collision avoidance: ||p_ego - p_obs||² ≥ r_safe²  at every Np step
+//   2. Lane keeping: |lateral_deviation| ≤ lane_half_width  at every Np step
+//
+// When a stopped car is ahead, the solver can't find a collision-free +
+// in-lane trajectory at the current speed → the optimal action is to brake.
+#pragma once
+
+#ifndef CARLA_CONSTRAINT_MPC_CONTROLLER_H
+#define CARLA_CONSTRAINT_MPC_CONTROLLER_H
+
+#include "controller.h"
+
+// Only compile when we have a 4-state kinematic model AND constraint slots
+#if TNX == 4 && defined(TNIEQ) && TNIEQ > 0
+
+#include <mpc/NLMPC.hpp>
+#include <mpc/Utils.hpp>
+#include <nlohmann/json.hpp>
+#include <vector>
+#include <cmath>
+#include <algorithm>
+#include <fstream>
+#include <string>
+
+using namespace mpc;
+
+class CarlaConstraintMPCController : public Controller {
+private:
+    static constexpr int Nx  = TNX;
+    static constexpr int Nu  = TNU;
+    static constexpr int Ndu = TNDU;
+    static constexpr int Ny  = TNY;
+    static constexpr int Np  = PREDICTION_HORIZON;
+    static constexpr int Nc  = CONTROL_HORIZON;
+    static constexpr int ineq_c = TNIEQ;  // Np * (n_obstacles + 1)
+    static constexpr int eq_c   = 0;
+
+    // Vehicle parameters
+    double wheelbase    = 2.87;
+    double sample_time  = 0.1;
+    double target_speed = 20.0;
+    double effective_target_speed = 20.0;  // adapted per step to leading vehicle
+
+    // Cost weights (tracking only — no obstacle cost terms)
+    double q_path     = 1.0;
+    double q_speed    = 0.5;
+    double r_accel    = 0.0;
+    double r_steer    = 0.0;
+    double r_jerk_v   = 0.1;
+    double r_jerk_yaw = 0.1;
+    double gamma      = 1.0;
+
+    // Constraint parameters
+    double ego_radius      = 2.5;   // ego bounding-circle radius [m]
+    double safe_margin      = 0.5;   // extra buffer beyond bounding radii [m]
+    double lane_half_width  = 1.75;  // half lane width [m]
+
+    // Input limits
+    double max_accel =  3.0;
+    double min_accel = -5.0;
+    double max_steer =  0.7;
+    double min_steer = -0.7;
+
+    // Waypoints & obstacles
+    int n_waypoints = 0;
+    int n_obstacles = 0;
+
+    NLMPC<Nx, Nu, Ny, Np, Nc, ineq_c, eq_c> nlmpc;
+    Result<Nu> mpc_result;
+
+    std::vector<double> wp_x, wp_y;
+
+    struct ObstacleData { double x, y, vx, vy, radius; };
+    std::vector<ObstacleData> obstacles;
+
+    double prev_accel = 0.0;
+    double prev_steer = 0.0;
+    bool   sticky_hold = false;   // Once stopped near obstacles, stay stopped
+    double min_clear_dist = 0.0;  // 2 * r_safe — release hold when all obs this far
+
+    std::string experiment_dir;
+    std::string state_file;
+    void save_state() const;
+    void load_state();
+
+    double closestWaypointDistSq(double px, double py) const;
+    double lateralDeviation(double px, double py) const;
+
+public:
+    CarlaConstraintMPCController(const nlohmann::json& json_data) : Controller(json_data) {
+        setup(json_data);
+    }
+
+    void calculateControl(int k, double t, const xVec& x, const wVec& w) override;
+
+protected:
+    void setup(const nlohmann::json& json_data) override;
+};
+
+#endif // TNX == 4 && TNIEQ > 0
+#endif // CARLA_CONSTRAINT_MPC_CONTROLLER_H

--- a/resources/controllers/include/CarlaKinematicMPPIController.h
+++ b/resources/controllers/include/CarlaKinematicMPPIController.h
@@ -1,0 +1,89 @@
+// controller/CarlaKinematicMPPIController.h
+#pragma once
+
+#ifndef CARLA_KINEMATIC_MPPI_CONTROLLER_H
+#define CARLA_KINEMATIC_MPPI_CONTROLLER_H
+
+#include "controller.h"
+#if TNX == 4
+
+#include <mpc/NLMPC.hpp>
+#include <mpc/Utils.hpp>
+#include <nlohmann/json.hpp>
+#include <vector>
+#include <cmath>
+#include <algorithm>
+#include <fstream>
+#include <string>
+
+using namespace mpc;
+
+class CarlaKinematicMPPIController : public Controller {
+private:
+    static constexpr int Nx  = TNX;
+    static constexpr int Nu  = TNU;
+    static constexpr int Ndu = TNDU;
+    static constexpr int Ny  = TNY;
+    static constexpr int Np  = PREDICTION_HORIZON;
+    static constexpr int Nc  = CONTROL_HORIZON;
+    static constexpr int ineq_c = 0;
+    static constexpr int eq_c   = 0;
+
+    double wheelbase = 2.87;
+    double sample_time   = 0.1;    // [s]
+    double target_speed  = 10.0;   // [m/s] reference speed
+
+    double q_path     = 1.0;   
+    double q_speed    = 0.5;   
+    double r_accel    = 0.0;   
+    double r_steer    = 0.0;   
+    double r_jerk_v   = 0.1;   
+    double r_jerk_yaw = 0.1;   
+    double gamma      = 1.0;   
+
+    // MPPI Parameters
+    int num_rollouts = 512;
+    double lambda = 1.0;
+    double sigma_accel = 0.1;
+    double sigma_steer = 0.1;
+    double rho = 0.2;
+    double beta = 0.9;
+
+    double max_accel =  3.0;  // [m/s^2]
+    double min_accel = -5.0;  // [m/s^2]
+    double max_steer =  0.7;  // [rad]
+    double min_steer = -0.7;  // [rad]
+
+    int n_waypoints = 0;
+
+    // Use dynamic allocation for NLMPC to pass OptimizerType at runtime
+    std::unique_ptr<mpc::NLMPC<>> nlmpc;
+    Result<> mpc_result;
+
+    std::vector<double> wp_x;
+    std::vector<double> wp_y;
+
+    double prev_accel = 0.0;
+    double prev_steer = 0.0;
+
+    std::string experiment_dir;
+    std::string state_file;
+    void save_state() const;
+    void load_state();
+
+    double closestWaypointDistSq(double px, double py) const;
+    void accelToThrottleBrake(double a, double& throttle, double& brake) const;
+
+public:
+    CarlaKinematicMPPIController(const nlohmann::json& json_data) : Controller(json_data) {
+        setup(json_data);
+    }
+
+    void calculateControl(int k, double t, const xVec& x, const wVec& w) override;
+
+protected:
+    void setup(const nlohmann::json& json_data) override;
+};
+
+#endif // TNX == 4
+#endif // CARLA_KINEMATIC_MPPI_CONTROLLER_H

--- a/resources/controllers/include/CarlaObstacleMPCController.h
+++ b/resources/controllers/include/CarlaObstacleMPCController.h
@@ -1,0 +1,96 @@
+// controller/CarlaObstacleMPCController.h
+// Obstacle-aware kinematic MPC controller.
+//   Proposal F (q_prog = 0): exponential repulsive barrier only
+//   Proposal E (q_prog > 0): barrier + forward-progress heading penalty
+#pragma once
+
+#ifndef CARLA_OBSTACLE_MPC_CONTROLLER_H
+#define CARLA_OBSTACLE_MPC_CONTROLLER_H
+
+#include "controller.h"
+#if TNX == 4
+
+#include <mpc/NLMPC.hpp>
+#include <mpc/Utils.hpp>
+#include <nlohmann/json.hpp>
+#include <vector>
+#include <cmath>
+#include <algorithm>
+#include <fstream>
+#include <string>
+
+using namespace mpc;
+
+class CarlaObstacleMPCController : public Controller {
+private:
+    static constexpr int Nx  = TNX;
+    static constexpr int Nu  = TNU;
+    static constexpr int Ndu = TNDU;
+    static constexpr int Ny  = TNY;
+    static constexpr int Np  = PREDICTION_HORIZON;
+    static constexpr int Nc  = CONTROL_HORIZON;
+    static constexpr int ineq_c = 0;
+    static constexpr int eq_c   = 0;
+
+    // Vehicle parameters
+    double wheelbase    = 2.87;
+    double sample_time  = 0.1;
+    double target_speed = 20.0;
+
+    // Cost weights — waypoint tracking & speed
+    double q_path     = 1.0;
+    double q_speed    = 0.5;
+    double r_accel    = 0.0;
+    double r_steer    = 0.0;
+    double r_jerk_v   = 0.1;
+    double r_jerk_yaw = 0.1;
+    double gamma      = 1.0;
+
+    // Obstacle avoidance weights
+    double q_obs      = 50.0;   // barrier amplitude
+    double sigma_obs  = 5.0;    // barrier width [m]
+    double q_prog     = 0.0;    // forward-progress weight (0 → Proposal F, >0 → Proposal E)
+    double ego_radius = 2.5;    // ego bounding-circle radius [m]
+
+    // Input limits
+    double max_accel =  3.0;
+    double min_accel = -5.0;
+    double max_steer =  0.7;
+    double min_steer = -0.7;
+
+    // Waypoints & obstacles
+    int n_waypoints = 0;
+    int n_obstacles = 0;
+
+    NLMPC<Nx, Nu, Ny, Np, Nc, ineq_c, eq_c> nlmpc;
+    Result<Nu> mpc_result;
+
+    std::vector<double> wp_x, wp_y;
+
+    struct ObstacleData { double x, y, vx, vy, radius; };
+    std::vector<ObstacleData> obstacles;
+
+    double prev_accel = 0.0;
+    double prev_steer = 0.0;
+
+    std::string experiment_dir;
+    std::string state_file;
+    void save_state() const;
+    void load_state();
+
+    double closestWaypointDistSq(double px, double py) const;
+    int    closestWaypointIndex(double px, double py) const;
+
+public:
+    CarlaObstacleMPCController(const nlohmann::json& json_data) : Controller(json_data) {
+        setup(json_data);
+    }
+
+    void calculateControl(int k, double t, const xVec& x, const wVec& w) override;
+
+protected:
+    void setup(const nlohmann::json& json_data) override;
+};
+
+#endif // TNX == 4
+#endif // CARLA_OBSTACLE_MPC_CONTROLLER_H

--- a/resources/controllers/src/CarlaConstraintMPCController.cpp
+++ b/resources/controllers/src/CarlaConstraintMPCController.cpp
@@ -1,0 +1,395 @@
+// controller/CarlaConstraintMPCController.cpp
+// Hard-constraint obstacle MPC:  no collisions + stay in lane.
+//
+//   Exogenous input layout (same as CarlaObstacleMPCController):
+//     w[0 .. 2*N_w-1]           = waypoints (wx1, wy1, …)
+//     w[2*N_w + 5*i + 0..4]    = obstacle i (x, y, vx, vy, radius)
+//   Sentinel: x ≥ 5e5 → empty slot.
+//
+//   Inequality constraints (all must be ≤ 0):
+//     For each prediction step j = 1..Np:
+//       - Per obstacle i:  r_safe² - ||p(j) - ô_i(j)||²   (collision)
+//       - Lane keeping:    lat_dev(j)² - half_w²            (lane)
+//     Total: Np * (N_obs + 1) = TNIEQ
+//
+//   On solver infeasibility → emergency brake (a = min_accel, δ = 0).
+
+#include "CarlaConstraintMPCController.h"
+
+#if TNX == 4 && defined(TNIEQ) && TNIEQ > 0
+#include "sharc/utils.hpp"
+#include "debug_levels.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <limits>
+#include <iostream>
+#include <Eigen/Dense>
+
+static constexpr double SENTINEL_THRESHOLD = 5e5;
+
+// ------------------------------------------------------------------ //
+//  Setup                                                              //
+// ------------------------------------------------------------------ //
+
+void CarlaConstraintMPCController::setup(const nlohmann::json& json_data) {
+    const auto& sp = json_data.at("system_parameters");
+
+    sample_time  = sp.at("sample_time").get<double>();
+    wheelbase    = sp.at("mpc_options").at("wheelbase").get<double>();
+    target_speed = sp.at("target_speed").get<double>();
+
+    // Cost weights (tracking only)
+    const auto& cost = sp.at("mpc_options").at("cost_weights");
+    q_path     = cost.at("q_path").get<double>();
+    q_speed    = cost.at("q_speed").get<double>();
+    r_accel    = cost.at("r_accel").get<double>();
+    r_steer    = cost.at("r_steer").get<double>();
+    r_jerk_v   = cost.at("r_jerk_v").get<double>();
+    r_jerk_yaw = cost.at("r_jerk_yaw").get<double>();
+    gamma      = cost.at("gamma").get<double>();
+
+    // Constraint parameters
+    ego_radius     = cost.value("ego_radius", 2.5);
+    safe_margin    = cost.value("safe_margin", 0.5);
+    lane_half_width = cost.value("lane_half_width", 1.75);
+
+    // Input limits
+    const auto& limits = sp.at("mpc_options").at("input_limits");
+    max_accel = limits.at("max_accel").get<double>();
+    min_accel = limits.at("min_accel").get<double>();
+    max_steer = limits.at("max_steer").get<double>();
+    min_steer = limits.at("min_steer").get<double>();
+
+    // Waypoints & obstacles
+    n_waypoints = sp.at("mpc_options").at("n_waypoints").get<int>();
+    n_obstacles = sp.at("mpc_options").at("n_obstacles").get<int>();
+    assert(Ndu == 2 * n_waypoints + 5 * n_obstacles
+           && "TNDU must equal 2*n_waypoints + 5*n_obstacles");
+    assert(ineq_c == Np * (n_obstacles + 1)
+           && "TNIEQ must equal Np * (n_obstacles + 1)");
+
+    wp_x.resize(n_waypoints);
+    wp_y.resize(n_waypoints);
+    obstacles.resize(n_obstacles);
+
+    // ---- NLMPC ---------------------------------------------------- //
+    nlmpc.setLoggerLevel(mpc::Logger::NORMAL);
+    nlmpc.setDiscretizationSamplingTime(sample_time);
+
+    // Kinematic bicycle model
+    nlmpc.setStateSpaceFunction(
+        [this](xVec& dx, const xVec& x, const uVec& u, const unsigned int&) {
+            double psi = x(2), v = x(3);
+            double a = u(0), delta = u(1);
+            dx(0) = v * std::cos(psi);
+            dx(1) = v * std::sin(psi);
+            dx(2) = (v / wheelbase) * std::tan(delta);
+            dx(3) = a;
+        });
+
+    // Objective: pure tracking (no obstacle terms — safety via constraints)
+    nlmpc.setObjectiveFunction(
+        [this](
+            const mpc::mat<Np + 1, Nx>& X,
+            const mpc::mat<Np + 1, Ny>&,
+            const mpc::mat<Np + 1, Nu>& U,
+            const double&) -> double
+        {
+            double J = 0.0;
+            double gj = gamma;
+            for (int j = 1; j <= Np; ++j) {
+                double px = X(j, 0), py = X(j, 1), v = X(j, 3);
+                J += gj * q_path * closestWaypointDistSq(px, py);
+                double ev = v - effective_target_speed;
+                J += gj * q_speed * ev * ev;
+                gj *= gamma;
+            }
+            // Control effort
+            double gk = 1.0;
+            for (int j = 0; j < Nc; ++j) {
+                J += gk * r_accel * U(j, 0) * U(j, 0);
+                J += gk * r_steer * U(j, 1) * U(j, 1);
+                gk *= gamma;
+            }
+            // Jerk penalty
+            {
+                double da = U(0, 0) - prev_accel;
+                double dd = U(0, 1) - prev_steer;
+                J += r_jerk_v * da * da;
+                J += r_jerk_yaw * dd * dd;
+            }
+            for (int j = 1; j < Nc; ++j) {
+                double da = U(j, 0) - U(j - 1, 0);
+                double dd = U(j, 1) - U(j - 1, 1);
+                J += r_jerk_v * da * da;
+                J += r_jerk_yaw * dd * dd;
+            }
+            return J;
+        });
+
+    // ---- Inequality constraints ----------------------------------- //
+    // Layout (all ≤ 0 for feasibility):
+    //   idx = (j-1)*(n_obstacles+1) + i    → collision with obstacle i at step j
+    //   idx = (j-1)*(n_obstacles+1) + n_obs → lane keeping at step j
+    nlmpc.setIneqConFunction(
+        [this](
+            cvec<ineq_c>& c,
+            const mpc::mat<Np + 1, Nx>& X,
+            const mpc::mat<Np + 1, Ny>&,
+            const mpc::mat<Np + 1, Nu>&,
+            const double&)
+        {
+            int idx = 0;
+            for (int j = 1; j <= Np; ++j) {
+                double px = X(j, 0);
+                double py = X(j, 1);
+                double dt_pred = j * sample_time;
+
+                // Collision avoidance
+                for (int i = 0; i < n_obstacles; ++i) {
+                    if (obstacles[i].x > SENTINEL_THRESHOLD) {
+                        c(idx++) = -1e6;  // trivially satisfied
+                        continue;
+                    }
+                    double ox = obstacles[i].x + dt_pred * obstacles[i].vx;
+                    double oy = obstacles[i].y + dt_pred * obstacles[i].vy;
+                    double r_safe = ego_radius + obstacles[i].radius + safe_margin;
+                    double dx = px - ox;
+                    double dy = py - oy;
+                    c(idx++) = r_safe * r_safe - (dx * dx + dy * dy);
+                }
+
+                // Lane keeping: lat_dev² ≤ half_w²
+                double ld = lateralDeviation(px, py);
+                c(idx++) = ld * ld - lane_half_width * lane_half_width;
+            }
+        });
+
+    // Input bounds
+    uVec umin, umax;
+    umin(0) = min_accel; umin(1) = min_steer;
+    umax(0) = max_accel; umax(1) = max_steer;
+    nlmpc.setInputBounds(umin, umax, {0, Nc});
+
+    control.setZero();
+
+    // State persistence
+    experiment_dir = json_data.value("experiment_dir", "");
+    state_file = experiment_dir.empty() ? "" : experiment_dir + "/mpc_state.json";
+    if (!state_file.empty()) load_state();
+}
+
+// ------------------------------------------------------------------ //
+//  Control step                                                       //
+// ------------------------------------------------------------------ //
+
+void CarlaConstraintMPCController::calculateControl(int k, double t,
+                                                     const xVec& x, const wVec& w) {
+    // Unpack waypoints
+    for (int i = 0; i < n_waypoints; ++i) {
+        wp_x[i] = w(2 * i);
+        wp_y[i] = w(2 * i + 1);
+    }
+
+    // Unpack obstacle slots
+    const int obs_offset = 2 * n_waypoints;
+    for (int i = 0; i < n_obstacles; ++i) {
+        obstacles[i].x      = w(obs_offset + 5 * i + 0);
+        obstacles[i].y      = w(obs_offset + 5 * i + 1);
+        obstacles[i].vx     = w(obs_offset + 5 * i + 2);
+        obstacles[i].vy     = w(obs_offset + 5 * i + 3);
+        obstacles[i].radius = w(obs_offset + 5 * i + 4);
+    }
+
+    state = x;
+
+    // --- Adapt reference speed to closest leading vehicle ----------------
+    effective_target_speed = target_speed;
+    {
+        double px = x(0), py = x(1), psi = x(2);
+        double cos_psi = std::cos(psi), sin_psi = std::sin(psi);
+        for (int i = 0; i < n_obstacles; ++i) {
+            if (obstacles[i].x > SENTINEL_THRESHOLD) continue;
+            double dx = obstacles[i].x - px;
+            double dy = obstacles[i].y - py;
+            double lon = dx * cos_psi + dy * sin_psi;  // ahead if > 0
+            if (lon > 0) {
+                // Project obstacle velocity onto ego heading
+                double obs_fwd_speed = obstacles[i].vx * cos_psi
+                                     + obstacles[i].vy * sin_psi;
+                effective_target_speed = std::min(effective_target_speed,
+                                                  std::max(obs_fwd_speed, 0.0));
+            }
+        }
+    }
+
+    // --- Sticky hold: once stopped near obstacles, stay stopped -----------
+    if (sticky_hold) {
+        bool all_clear = true;
+        double px = x(0), py = x(1);
+        for (int i = 0; i < n_obstacles; ++i) {
+            if (obstacles[i].x > SENTINEL_THRESHOLD) continue;
+            double dx = px - obstacles[i].x;
+            double dy = py - obstacles[i].y;
+            double dist = std::sqrt(dx * dx + dy * dy);
+            double r_safe = ego_radius + obstacles[i].radius + safe_margin;
+            if (dist < 2.0 * r_safe) { all_clear = false; break; }
+        }
+        if (all_clear) {
+            sticky_hold = false;
+        } else {
+            control(0) = 0.0;
+            control(1) = 0.0;
+            int active_obs = 0;
+            for (int i = 0; i < n_obstacles; ++i)
+                if (obstacles[i].x < SENTINEL_THRESHOLD) ++active_obs;
+            std::cout << "[CarlaConstraintMPC] k=" << k
+                      << " STICKY_HOLD v=" << x(3)
+                      << " obs=" << active_obs << "/" << n_obstacles
+                      << std::endl;
+            latest_metadata.clear();
+            latest_metadata["k"] = k;
+            latest_metadata["controller"] = "CarlaConstraintMPCController";
+            latest_metadata["is_feasible"] = false;
+            latest_metadata["sticky_hold"] = true;
+            prev_accel = 0.0;
+            prev_steer = 0.0;
+            if (!state_file.empty()) save_state();
+            return;
+        }
+    }
+
+    mpc_result = nlmpc.optimize(state, control);
+
+    // Count active obstacles
+    int active_obs = 0;
+    for (int i = 0; i < n_obstacles; ++i)
+        if (obstacles[i].x < SENTINEL_THRESHOLD) ++active_obs;
+
+    // On infeasibility → emergency brake (or hold if already stopped)
+    if (!mpc_result.is_feasible) {
+        double v = x(3);
+        if (std::abs(v) < 0.1) {
+            // Already (nearly) stopped — hold position, engage sticky hold
+            control(0) = 0.0;
+            control(1) = 0.0;
+            if (active_obs > 0) sticky_hold = true;
+        } else {
+            // Still moving — hard brake
+            control(0) = min_accel;
+            control(1) = 0.0;
+        }
+        std::cout << "[CarlaConstraintMPC] k=" << k
+                  << " INFEASIBLE → " << (std::abs(v) < 0.1 ? "HOLD" : "BRAKE")
+                  << " a=" << control(0) << " v=" << v
+                  << " obs=" << active_obs << "/" << n_obstacles
+                  << std::endl;
+    } else {
+        control = mpc_result.cmd;
+        std::cout << "[CarlaConstraintMPC] k=" << k
+                  << " a=" << control(0) << " delta=" << control(1)
+                  << " cost=" << mpc_result.cost
+                  << " obs=" << active_obs << "/" << n_obstacles
+                  << std::endl;
+    }
+
+    // Metadata for logging / trajectory drawing
+    latest_metadata.clear();
+    latest_metadata["k"]             = k;
+    latest_metadata["t"]             = t;
+    latest_metadata["controller"]    = "CarlaConstraintMPCController";
+    latest_metadata["solver_status"] = mpc_result.solver_status;
+    latest_metadata["is_feasible"]   = mpc_result.is_feasible;
+    latest_metadata["cost"]          = mpc_result.cost;
+
+    auto opt_seq = nlmpc.getOptimalSequence();
+    std::vector<double> traj_x, traj_y;
+    for (int j = 0; j <= Np; ++j) {
+        traj_x.push_back(opt_seq.state(j, 0));
+        traj_y.push_back(opt_seq.state(j, 1));
+    }
+    latest_metadata["traj_x"] = traj_x;
+    latest_metadata["traj_y"] = traj_y;
+
+    prev_accel = control(0);
+    prev_steer = control(1);
+
+    if (!state_file.empty()) save_state();
+}
+
+// ------------------------------------------------------------------ //
+//  State persistence                                                  //
+// ------------------------------------------------------------------ //
+
+void CarlaConstraintMPCController::save_state() const {
+    nlohmann::json s;
+    s["prev_accel"]  = prev_accel;
+    s["prev_steer"]  = prev_steer;
+    s["sticky_hold"] = sticky_hold;
+    std::ofstream f(state_file);
+    if (f.is_open()) f << s.dump(2);
+}
+
+void CarlaConstraintMPCController::load_state() {
+    std::ifstream f(state_file);
+    if (!f.is_open()) return;
+    try {
+        nlohmann::json s;
+        f >> s;
+        prev_accel   = s.value("prev_accel", 0.0);
+        prev_steer   = s.value("prev_steer", 0.0);
+        sticky_hold  = s.value("sticky_hold", false);
+    } catch (...) {}
+}
+
+// ------------------------------------------------------------------ //
+//  Helpers                                                            //
+// ------------------------------------------------------------------ //
+
+double CarlaConstraintMPCController::closestWaypointDistSq(double px, double py) const {
+    double best = std::numeric_limits<double>::max();
+    for (int i = 0; i < n_waypoints; ++i) {
+        double dx = px - wp_x[i];
+        double dy = py - wp_y[i];
+        double d2 = dx * dx + dy * dy;
+        if (d2 < best) best = d2;
+    }
+    return best;
+}
+
+double CarlaConstraintMPCController::lateralDeviation(double px, double py) const {
+    // Perpendicular distance from (px,py) to the closest waypoint segment.
+    // Sign comes from the cross-product: positive = left of path.
+    double min_proj_dist_sq = std::numeric_limits<double>::max();
+    double best_lat = 0.0;
+
+    for (int i = 0; i < n_waypoints - 1; ++i) {
+        double ax = wp_x[i],     ay = wp_y[i];
+        double bx = wp_x[i + 1], by = wp_y[i + 1];
+
+        double abx = bx - ax, aby = by - ay;
+        double apx = px - ax, apy = py - ay;
+        double ab_len_sq = abx * abx + aby * aby;
+        if (ab_len_sq < 1e-12) continue;
+
+        // Project onto segment, clamp to [0, 1]
+        double t = std::max(0.0, std::min(1.0,
+                   (apx * abx + apy * aby) / ab_len_sq));
+
+        double cx = ax + t * abx;
+        double cy = ay + t * aby;
+        double dx = px - cx, dy = py - cy;
+        double dist_sq = dx * dx + dy * dy;
+
+        if (dist_sq < min_proj_dist_sq) {
+            min_proj_dist_sq = dist_sq;
+            // Signed lateral deviation via cross product
+            best_lat = (abx * apy - aby * apx) / std::sqrt(ab_len_sq);
+        }
+    }
+    return best_lat;
+}
+
+REGISTER_CONTROLLER("CarlaConstraintMPCController", CarlaConstraintMPCController)
+#endif

--- a/resources/controllers/src/CarlaKinematicMPPIController.cpp
+++ b/resources/controllers/src/CarlaKinematicMPPIController.cpp
@@ -1,0 +1,236 @@
+// controller/CarlaKinematicMPPIController.cpp
+#include "CarlaKinematicMPPIController.h"
+
+#if TNX == 4
+#include "sharc/utils.hpp"
+#include "debug_levels.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <limits>
+#include <iostream>
+#include <Eigen/Dense>
+
+void CarlaKinematicMPPIController::setup(const nlohmann::json& json_data) {
+    if (global_debug_levels.debug_program_flow_level >= 2) {
+        PRINT_WITH_FILE_LOCATION("Start of CarlaKinematicMPPIController::setup()")
+    }
+
+    const auto& sp = json_data.at("system_parameters");
+
+    // --- Vehicle / timing ------------------------------------------------ //
+    sample_time  = sp.at("sample_time").get<double>();
+    wheelbase    = sp.at("mpc_options").at("wheelbase").get<double>();
+    target_speed = sp.at("target_speed").get<double>();
+
+    // --- Cost weights ---------------------------------------------------- //
+    const auto& cost = sp.at("mpc_options").at("cost_weights");
+    q_path     = cost.at("q_path").get<double>();
+    q_speed    = cost.at("q_speed").get<double>();
+    r_accel    = cost.at("r_accel").get<double>();
+    r_steer    = cost.at("r_steer").get<double>();
+    r_jerk_v   = cost.at("r_jerk_v").get<double>();
+    r_jerk_yaw = cost.at("r_jerk_yaw").get<double>();
+    gamma      = cost.at("gamma").get<double>();
+
+    // --- MPPI Options ---------------------------------------------------- //
+    if (sp.at("mpc_options").contains("mppi_options")) {
+        const auto& mppi = sp.at("mpc_options").at("mppi_options");
+        num_rollouts = mppi.at("num_rollouts").get<int>();
+        lambda       = mppi.at("lambda").get<double>();
+        sigma_accel  = mppi.at("sigma_accel").get<double>();
+        sigma_steer  = mppi.at("sigma_steer").get<double>();
+        rho          = mppi.at("rho").get<double>();
+        beta         = mppi.at("beta").get<double>();
+    }
+
+    // --- Input limits ---------------------------------------------------- //
+    const auto& limits = sp.at("mpc_options").at("input_limits");
+    max_accel = limits.at("max_accel").get<double>();
+    min_accel = limits.at("min_accel").get<double>();
+    max_steer = limits.at("max_steer").get<double>();
+    min_steer = limits.at("min_steer").get<double>();
+
+    // --- Waypoints ------------------------------------------------------- //
+    n_waypoints = sp.at("mpc_options").at("n_waypoints").get<int>();
+    assert(Ndu == 2 * n_waypoints && "TNDU must equal 2 * n_waypoints");
+
+    wp_x.resize(n_waypoints);
+    wp_y.resize(n_waypoints);
+
+    // --- MPPI configuration --------------------------------------------- //
+    // Using the explicitly confirmed types and enums from libmpc 1.0.0
+    nlmpc = std::make_unique<mpc::NLMPC<>>(Nx, Nu, Ny, Np, Nc, ineq_c, eq_c, mpc::MPPI);
+    nlmpc->setLoggerLevel(mpc::Logger::NORMAL);
+
+    // Sample time for discrete simulation in MPPI
+    nlmpc->setDiscretizationSamplingTime(sample_time);
+
+    // Kinematic model: px, py, psi, v
+    nlmpc->setStateSpaceFunction([this](cvec<>& dx, const cvec<>& x, const cvec<>& u, const unsigned int&) {
+        const double psi   = x(2);
+        const double v     = x(3);
+        const double a     = u(0);
+        const double delta = u(1);
+        dx(0) = v * std::cos(psi);
+        dx(1) = v * std::sin(psi);
+        dx(2) = (v / wheelbase) * std::tan(delta);
+        dx(3) = a;
+    });
+
+    nlmpc->setOutputFunction([](cvec<>& y, const cvec<>& x, const cvec<>&, const unsigned int&) {
+        y << x(0), x(1);
+    });
+
+    // MPPI objective
+    nlmpc->setObjectiveFunction([this](const mat<>& X, const mat<>& Y, const mat<>& U, const double&) {
+        double total_cost = 0.0;
+        for (int i = 0; i <= Np; ++i) {
+            double px = X(i, 0);
+            double py = X(i, 1);
+            double d2 = closestWaypointDistSq(px, py);
+            
+            double v = X(i, 3);
+            double ev = v - target_speed;
+            
+            double stage_cost = q_path * d2 + q_speed * ev * ev;
+            total_cost += stage_cost;
+            
+            if (i < Nc) {
+                total_cost += r_accel * U(i, 0) * U(i, 0) + r_steer * U(i, 1) * U(i, 1);
+            }
+        }
+        return total_cost;
+    });
+
+    // MPPI Parameters
+    mpc::MPPIParameters p;
+    p.num_rollouts = (size_t)num_rollouts;
+    p.maximum_iteration = 10; // Standard for MPPI control
+    p.lambda = lambda;
+    p.sigma.resize(Nu);
+    p.sigma << sigma_accel, sigma_steer;
+    p.rho = rho;
+    p.beta = beta;
+    p.integration_substeps = 5;
+    
+    nlmpc->setOptimizerParameters(p);
+
+    // Input bounds
+    cvec<Nu> umin, umax;
+    umin(0) = min_accel; umin(1) = min_steer;
+    umax(0) = max_accel; umax(1) = max_steer;
+    nlmpc->setInputBounds(umin, umax, {0, Nc});
+
+    control.setZero();
+
+    experiment_dir = json_data.value("experiment_dir", "");
+    state_file     = experiment_dir.empty() ? "" : experiment_dir + "/mppi_state.json";
+    if (!state_file.empty())
+        load_state();
+
+    if (global_debug_levels.debug_program_flow_level >= 2) {
+        PRINT_WITH_FILE_LOCATION("End of CarlaKinematicMPPIController::setup()")
+    }
+}
+
+void CarlaKinematicMPPIController::calculateControl(int k, double t,
+                                           const xVec& x, const wVec& w) {
+    // Input Validation
+    for (int i = 0; i < x.size(); ++i) {
+        if (std::isnan(x(i)) || std::isinf(x(i))) {
+            std::cerr << "[CarlaKinematicMPPI] CRITICAL: NaN/Inf detected in state x(" << i << ")=" << x(i) << " at k=" << k << std::endl;
+            return;
+        }
+    }
+    for (int i = 0; i < w.size(); ++i) {
+        if (std::isnan(w(i)) || std::isinf(w(i))) {
+            std::cerr << "[CarlaKinematicMPPI] CRITICAL: NaN/Inf detected in waypoints w(" << i << ")=" << w(i) << " at k=" << k << std::endl;
+            return;
+        }
+    }
+
+    for (int i = 0; i < n_waypoints; ++i) {
+        wp_x[i] = w(2 * i);
+        wp_y[i] = w(2 * i + 1);
+    }
+    state = x;
+
+    // In libmpc 1.0.0, the command is in the Result struct
+    mpc_result = nlmpc->optimize(state, control);
+    control    = mpc_result.cmd;
+
+    latest_metadata.clear();
+    latest_metadata["k"]                = k;
+    latest_metadata["t"]                = t;
+    latest_metadata["controller"]       = "CarlaKinematicMPPIController";
+    latest_metadata["cost"]             = mpc_result.cost;
+    latest_metadata["iterations"]       = 100;
+    latest_metadata["status"]           = "Success";
+    latest_metadata["constraint_error"] = 0.0;
+    latest_metadata["dual_residual"]     = 0.0;
+
+    auto opt_seq = nlmpc->getOptimalSequence();
+    std::vector<double> traj_x, traj_y;
+    for (int j = 0; j <= Np; ++j) {
+        traj_x.push_back(opt_seq.state(j, 0));
+        traj_y.push_back(opt_seq.state(j, 1));
+    }
+    latest_metadata["traj_x"] = traj_x;
+    latest_metadata["traj_y"] = traj_y;
+
+    std::cout << "[CarlaKinematicMPPI] k=" << k
+              << " a=" << control(0) << " delta=" << control(1)
+              << " cost=" << mpc_result.cost << std::endl;
+
+    prev_accel = control(0);
+    prev_steer = control(1);
+
+    if (!state_file.empty())
+        save_state();
+}
+
+void CarlaKinematicMPPIController::save_state() const {
+    nlohmann::json s;
+    s["prev_accel"] = prev_accel;
+    s["prev_steer"] = prev_steer;
+    std::ofstream f(state_file);
+    if (f.is_open()) f << s.dump(2);
+}
+
+void CarlaKinematicMPPIController::load_state() {
+    std::ifstream f(state_file);
+    if (!f.is_open()) return;
+    try {
+        nlohmann::json s;
+        f >> s;
+        prev_accel  = s.value("prev_accel", 0.0);
+        prev_steer  = s.value("prev_steer", 0.0);
+    } catch (...) {}
+}
+
+double CarlaKinematicMPPIController::closestWaypointDistSq(double px, double py) const {
+    double best = std::numeric_limits<double>::max();
+    for (int i = 0; i < n_waypoints; ++i) {
+        double dx = px - wp_x[i];
+        double dy = py - wp_y[i];
+        double d2 = dx * dx + dy * dy;
+        if (d2 < best) best = d2;
+    }
+    return best;
+}
+
+void CarlaKinematicMPPIController::accelToThrottleBrake(double a,
+                                               double& throttle,
+                                               double& brake) const {
+    if (a >= 0.0) {
+        throttle = std::min(a / max_accel, 1.0);
+        brake    = 0.0;
+    } else {
+        throttle = 0.0;
+        brake    = std::min(-a / (-min_accel), 1.0);
+    }
+}
+
+REGISTER_CONTROLLER("CarlaKinematicMPPIController", CarlaKinematicMPPIController)
+#endif

--- a/resources/controllers/src/CarlaObstacleMPCController.cpp
+++ b/resources/controllers/src/CarlaObstacleMPCController.cpp
@@ -1,0 +1,317 @@
+// controller/CarlaObstacleMPCController.cpp
+// Obstacle-aware kinematic bicycle-model MPC.
+//   Exogenous input layout:
+//     w[0 .. 2*N_w-1]                   = waypoints  (wx1, wy1, …)
+//     w[2*N_w + 5*i + 0..4]             = obstacle i (x, y, vx, vy, radius)
+//   Sentinel: obstacle slot with x ≥ 5e5 is treated as empty.
+
+#include "CarlaObstacleMPCController.h"
+
+#if TNX == 4
+#include "sharc/utils.hpp"
+#include "debug_levels.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <limits>
+#include <iostream>
+#include <Eigen/Dense>
+
+static constexpr double SENTINEL_THRESHOLD = 5e5;
+
+// Numerically stable softplus: log(1 + exp(x))
+static inline double softplus(double x) {
+    if (x > 20.0) return x;           // avoid exp overflow
+    if (x < -20.0) return std::exp(x); // negligible
+    return std::log(1.0 + std::exp(x));
+}
+
+// ------------------------------------------------------------------ //
+//  Setup                                                              //
+// ------------------------------------------------------------------ //
+
+void CarlaObstacleMPCController::setup(const nlohmann::json& json_data) {
+    if (global_debug_levels.debug_program_flow_level >= 2) {
+        PRINT_WITH_FILE_LOCATION("Start of CarlaObstacleMPCController::setup()")
+    }
+
+    const auto& sp = json_data.at("system_parameters");
+
+    // --- Vehicle / timing ------------------------------------------------ //
+    sample_time  = sp.at("sample_time").get<double>();
+    wheelbase    = sp.at("mpc_options").at("wheelbase").get<double>();
+    target_speed = sp.at("target_speed").get<double>();
+
+    // --- Cost weights — tracking ----------------------------------------- //
+    const auto& cost = sp.at("mpc_options").at("cost_weights");
+    q_path     = cost.at("q_path").get<double>();
+    q_speed    = cost.at("q_speed").get<double>();
+    r_accel    = cost.at("r_accel").get<double>();
+    r_steer    = cost.at("r_steer").get<double>();
+    r_jerk_v   = cost.at("r_jerk_v").get<double>();
+    r_jerk_yaw = cost.at("r_jerk_yaw").get<double>();
+    gamma      = cost.at("gamma").get<double>();
+
+    // --- Cost weights — obstacle avoidance ------------------------------- //
+    q_obs      = cost.at("q_obs").get<double>();
+    sigma_obs  = cost.at("sigma_obs").get<double>();
+    q_prog     = cost.value("q_prog", 0.0);        // 0 → Proposal F
+    ego_radius = cost.value("ego_radius", 2.5);
+
+    // --- Input limits ---------------------------------------------------- //
+    const auto& limits = sp.at("mpc_options").at("input_limits");
+    max_accel = limits.at("max_accel").get<double>();
+    min_accel = limits.at("min_accel").get<double>();
+    max_steer = limits.at("max_steer").get<double>();
+    min_steer = limits.at("min_steer").get<double>();
+
+    // --- Waypoints & obstacles ------------------------------------------- //
+    n_waypoints = sp.at("mpc_options").at("n_waypoints").get<int>();
+    n_obstacles = sp.at("mpc_options").at("n_obstacles").get<int>();
+    assert(Ndu == 2 * n_waypoints + 5 * n_obstacles
+           && "TNDU must equal 2*n_waypoints + 5*n_obstacles");
+
+    wp_x.resize(n_waypoints);
+    wp_y.resize(n_waypoints);
+    obstacles.resize(n_obstacles);
+
+    // --- NLMPC configuration --------------------------------------------- //
+    nlmpc.setLoggerLevel(mpc::Logger::NORMAL);
+    nlmpc.setDiscretizationSamplingTime(sample_time);
+
+    // Kinematic bicycle model: x = [px, py, psi, v]
+    nlmpc.setStateSpaceFunction(
+        [this](xVec& dx, const xVec& x, const uVec& u, const unsigned int&) {
+            const double psi   = x(2);
+            const double v     = x(3);
+            const double a     = u(0);
+            const double delta = u(1);
+
+            dx(0) = v * std::cos(psi);
+            dx(1) = v * std::sin(psi);
+            dx(2) = (v / wheelbase) * std::tan(delta);
+            dx(3) = a;
+        });
+
+    // Objective function — waypoint + speed + obstacle barrier + forward progress
+    nlmpc.setObjectiveFunction(
+        [this](
+            const mpc::mat<Np + 1, Nx>& X,
+            const mpc::mat<Np + 1, Ny>&,
+            const mpc::mat<Np + 1, Nu>& U,
+            const double&) -> double
+        {
+            double J = 0.0;
+            double gj = gamma;
+
+            for (int j = 1; j <= Np; ++j) {
+                const double px  = X(j, 0);
+                const double py  = X(j, 1);
+                const double psi = X(j, 2);
+                const double v   = X(j, 3);
+
+                // ---- Waypoint tracking ---- //
+                double dmin_sq = closestWaypointDistSq(px, py);
+                J += gj * q_path * dmin_sq;
+
+                // ---- Speed tracking ---- //
+                double ev = v - target_speed;
+                J += gj * q_speed * ev * ev;
+
+                // ---- Obstacle repulsive barrier ---- //
+                const double dt_pred = j * sample_time;
+                for (int i = 0; i < n_obstacles; ++i) {
+                    if (obstacles[i].x > SENTINEL_THRESHOLD) continue;
+
+                    // Constant-velocity prediction
+                    double ox = obstacles[i].x  + dt_pred * obstacles[i].vx;
+                    double oy = obstacles[i].y  + dt_pred * obstacles[i].vy;
+                    double r  = obstacles[i].radius;
+
+                    double dx_o = px - ox;
+                    double dy_o = py - oy;
+                    double center_dist_sq = dx_o * dx_o + dy_o * dy_o;
+
+                    // Effective distance: subtract combined bounding radii
+                    double combined_r  = ego_radius + r;
+                    double d_eff_sq    = center_dist_sq - combined_r * combined_r;
+                    if (d_eff_sq < 0.0) d_eff_sq = 0.0;  // overlapping → max penalty
+
+                    J += gj * q_obs * std::exp(-d_eff_sq / (2.0 * sigma_obs * sigma_obs));
+                }
+
+                // ---- Forward-progress heading penalty (Proposal E) ---- //
+                if (q_prog > 0.0) {
+                    int wp_idx     = closestWaypointIndex(px, py);
+                    int target_idx = std::min(wp_idx + 1, n_waypoints - 1);
+                    double dx_wp   = wp_x[target_idx] - px;
+                    double dy_wp   = wp_y[target_idx] - py;
+                    double theta_wp = std::atan2(dy_wp, dx_wp);
+
+                    // Penalise negative forward velocity along waypoint heading
+                    double forward = v * std::cos(psi - theta_wp);
+                    J += gj * q_prog * softplus(-forward);
+                }
+
+                gj *= gamma;
+            }
+
+            // ---- Control effort ---- //
+            double gk = 1.0;
+            for (int j = 0; j < Nc; ++j) {
+                J += gk * r_accel * U(j, 0) * U(j, 0);
+                J += gk * r_steer * U(j, 1) * U(j, 1);
+                gk *= gamma;
+            }
+
+            // ---- Jerk penalty ---- //
+            {
+                double da = U(0, 0) - prev_accel;
+                double dd = U(0, 1) - prev_steer;
+                J += r_jerk_v   * da * da;
+                J += r_jerk_yaw * dd * dd;
+            }
+            for (int j = 1; j < Nc; ++j) {
+                double da = U(j, 0) - U(j - 1, 0);
+                double dd = U(j, 1) - U(j - 1, 1);
+                J += r_jerk_v   * da * da;
+                J += r_jerk_yaw * dd * dd;
+            }
+
+            return J;
+        });
+
+    // Input bounds
+    uVec umin, umax;
+    umin(0) = min_accel; umin(1) = min_steer;
+    umax(0) = max_accel; umax(1) = max_steer;
+    nlmpc.setInputBounds(umin, umax, {0, Nc});
+
+    control.setZero();
+
+    // State persistence
+    experiment_dir = json_data.value("experiment_dir", "");
+    state_file     = experiment_dir.empty() ? "" : experiment_dir + "/mpc_state.json";
+    if (!state_file.empty())
+        load_state();
+
+    if (global_debug_levels.debug_program_flow_level >= 2) {
+        PRINT_WITH_FILE_LOCATION("End of CarlaObstacleMPCController::setup()")
+    }
+}
+
+// ------------------------------------------------------------------ //
+//  Control step                                                       //
+// ------------------------------------------------------------------ //
+
+void CarlaObstacleMPCController::calculateControl(int k, double t,
+                                                   const xVec& x, const wVec& w) {
+    // Unpack waypoints
+    for (int i = 0; i < n_waypoints; ++i) {
+        wp_x[i] = w(2 * i);
+        wp_y[i] = w(2 * i + 1);
+    }
+
+    // Unpack obstacle slots
+    const int obs_offset = 2 * n_waypoints;
+    for (int i = 0; i < n_obstacles; ++i) {
+        obstacles[i].x      = w(obs_offset + 5 * i + 0);
+        obstacles[i].y      = w(obs_offset + 5 * i + 1);
+        obstacles[i].vx     = w(obs_offset + 5 * i + 2);
+        obstacles[i].vy     = w(obs_offset + 5 * i + 3);
+        obstacles[i].radius = w(obs_offset + 5 * i + 4);
+    }
+
+    state = x;
+
+    mpc_result = nlmpc.optimize(state, control);
+    control    = mpc_result.cmd;
+
+    // Metadata for logging / plotting
+    latest_metadata.clear();
+    latest_metadata["k"]             = k;
+    latest_metadata["t"]             = t;
+    latest_metadata["controller"]    = "CarlaObstacleMPCController";
+    latest_metadata["solver_status"] = mpc_result.solver_status;
+    latest_metadata["is_feasible"]   = mpc_result.is_feasible;
+    latest_metadata["cost"]          = mpc_result.cost;
+
+    auto opt_seq = nlmpc.getOptimalSequence();
+    std::vector<double> traj_x, traj_y;
+    for (int j = 0; j <= Np; ++j) {
+        traj_x.push_back(opt_seq.state(j, 0));
+        traj_y.push_back(opt_seq.state(j, 1));
+    }
+    latest_metadata["traj_x"] = traj_x;
+    latest_metadata["traj_y"] = traj_y;
+
+    // Count active obstacles for console log
+    int active_obs = 0;
+    for (int i = 0; i < n_obstacles; ++i)
+        if (obstacles[i].x < SENTINEL_THRESHOLD) ++active_obs;
+
+    std::cout << "[CarlaObstacleMPC] k=" << k
+              << " a=" << control(0) << " delta=" << control(1)
+              << " cost=" << mpc_result.cost
+              << " obs=" << active_obs << "/" << n_obstacles
+              << std::endl;
+
+    prev_accel = control(0);
+    prev_steer = control(1);
+
+    if (!state_file.empty())
+        save_state();
+}
+
+// ------------------------------------------------------------------ //
+//  State persistence                                                  //
+// ------------------------------------------------------------------ //
+
+void CarlaObstacleMPCController::save_state() const {
+    nlohmann::json s;
+    s["prev_accel"] = prev_accel;
+    s["prev_steer"] = prev_steer;
+    std::ofstream f(state_file);
+    if (f.is_open()) f << s.dump(2);
+}
+
+void CarlaObstacleMPCController::load_state() {
+    std::ifstream f(state_file);
+    if (!f.is_open()) return;
+    try {
+        nlohmann::json s;
+        f >> s;
+        prev_accel = s.value("prev_accel", 0.0);
+        prev_steer = s.value("prev_steer", 0.0);
+    } catch (...) {}
+}
+
+// ------------------------------------------------------------------ //
+//  Helpers                                                            //
+// ------------------------------------------------------------------ //
+
+double CarlaObstacleMPCController::closestWaypointDistSq(double px, double py) const {
+    double best = std::numeric_limits<double>::max();
+    for (int i = 0; i < n_waypoints; ++i) {
+        double dx = px - wp_x[i];
+        double dy = py - wp_y[i];
+        double d2 = dx * dx + dy * dy;
+        if (d2 < best) best = d2;
+    }
+    return best;
+}
+
+int CarlaObstacleMPCController::closestWaypointIndex(double px, double py) const {
+    double best = std::numeric_limits<double>::max();
+    int idx = 0;
+    for (int i = 0; i < n_waypoints; ++i) {
+        double dx = px - wp_x[i];
+        double dy = py - wp_y[i];
+        double d2 = dx * dx + dy * dy;
+        if (d2 < best) { best = d2; idx = i; }
+    }
+    return idx;
+}
+
+REGISTER_CONTROLLER("CarlaObstacleMPCController", CarlaObstacleMPCController)
+#endif

--- a/resources/dynamics/carla_dynamics.py
+++ b/resources/dynamics/carla_dynamics.py
@@ -5,9 +5,18 @@ import carla
 import random
 import pygame
 import sys
+import os
+
+
+def _has_display():
+    """Return True if a graphical display is available."""
+    return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
 
 
 def pygame_init(w=1280, h=720):
+    if not _has_display():
+        print("[CarlaDynamics] No display detected — running headless (no pygame window).")
+        return None
     pygame.init()
     display = pygame.display.set_mode((w, h), pygame.HWSURFACE | pygame.DOUBLEBUF)
     pygame.display.set_caption("CARLA Camera View")
@@ -42,6 +51,8 @@ class CameraManager:
         self.camera.listen(lambda data: self._on_image(data))
 
     def _on_image(self, image):
+        if not _has_display():
+            return
         # Convert raw BGRA -> RGB array for pygame
         img = np.frombuffer(image.raw_data, dtype=np.uint8)
         img = img.reshape((self.height, self.width, 4))
@@ -142,9 +153,13 @@ class CarlaDynamics(Dynamics):
             bp_lib, n_walkers
         )
 
-        # ---- Pygame display & camera --------------------------------- #
+        # ---- Pygame display & camera (skip in headless mode) ----------- #
         self.display = pygame_init()
-        self.camera_manager = CameraManager(self.world, self.vehicle)
+        if _has_display():
+            self.camera_manager = CameraManager(self.world, self.vehicle)
+        else:
+            self.camera_manager = None
+            print("[CarlaDynamics] Headless mode — camera window disabled.")
 
     def teardown(self):
         """Destroy all CARLA actors (NPCs, ego, camera) and quit pygame.
@@ -197,7 +212,8 @@ class CarlaDynamics(Dynamics):
             if hasattr(self, 'traffic_manager'):
                 self.traffic_manager.set_synchronous_mode(False)
 
-            pygame.quit()
+            if _has_display():
+                pygame.quit()
         except Exception as e:
             print(f"[CarlaDynamics] cleanup error: {e}")
 
@@ -322,10 +338,11 @@ class CarlaDynamics(Dynamics):
                 brake=brake
             ))
 
-            # --- NEW: Render camera frame ----------------------------------------
-            if self.camera_manager.surface is not None:
-                self.display.blit(self.camera_manager.surface, (0, 0))
-            pygame.display.flip()
+            # --- NEW: Render camera frame (skip when headless) ---------------
+            if self.display is not None and self.camera_manager is not None:
+                if self.camera_manager.surface is not None:
+                    self.display.blit(self.camera_manager.surface, (0, 0))
+                pygame.display.flip()
 
             # Logging Information (Bypassing stdout redirection to log file)
             log_msg = (

--- a/resources/dynamics/carla_mpc_dynamics.py
+++ b/resources/dynamics/carla_mpc_dynamics.py
@@ -8,7 +8,9 @@ Differences from the PID-oriented CarlaDynamics:
   * Converts acceleration → CARLA throttle/brake internally.
 """
 
+import json
 import math
+import os
 import numpy as np
 from sharc.dynamics_base import Dynamics
 import carla
@@ -17,7 +19,15 @@ import pygame
 import sys
 
 
+def _has_display():
+    """Return True if a graphical display is available."""
+    return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+
+
 def pygame_init(w=1280, h=720):
+    if not _has_display():
+        print("[CarlaMPCDynamics] No display detected — running headless (no pygame window).")
+        return None
     pygame.init()
     display = pygame.display.set_mode((w, h), pygame.HWSURFACE | pygame.DOUBLEBUF)
     pygame.display.set_caption("CARLA Camera View — MPC")
@@ -46,6 +56,8 @@ class CameraManager:
         self.camera.listen(lambda data: self._on_image(data))
 
     def _on_image(self, image):
+        if not _has_display():
+            return
         img = np.frombuffer(image.raw_data, dtype=np.uint8)
         img = img.reshape((self.height, self.width, 4))
         img = img[:, :, :3][:, :, ::-1]
@@ -85,13 +97,17 @@ class CarlaMPCDynamics(Dynamics):
         self.n_wp     = mpc_opts.get("n_waypoints", 10)
         self.wp_spacing = mpc_opts.get("waypoint_spacing", 2.0)
 
+        # Obstacle-aware MPC options (0 disables obstacle packing)
+        self.n_obs            = mpc_opts.get("n_obstacles", 0)
+        self.detection_radius = mpc_opts.get("detection_radius", 30.0)
+
         random.seed(self.seed)
         np.random.seed(self.seed)
 
         # ---- Connect to CARLA ---------------------------------------- #
         print("[CarlaMPCDynamics] Creating CARLA session …")
         self.client = carla.Client("localhost", 2000)
-        self.client.set_timeout(10.0)
+        self.client.set_timeout(60.0)   # generous timeout; nullrhi can be slow to settle
         self.world = self.client.get_world()
 
         # Reset to async mode first (in case previous run left sync on)
@@ -153,19 +169,105 @@ class CarlaMPCDynamics(Dynamics):
         self.npc_vehicles = self._spawn_npc_vehicles(bp_lib, spawn_points, ego_spawn_idx, n_vehicles)
         self.npc_walkers, self.npc_walker_controllers = self._spawn_npc_walkers(bp_lib, n_walkers)
 
-        # ---- Pygame + camera ----------------------------------------- #
+        # ---- Force all traffic lights to stay green ------------------- #
+        for tl in self.world.get_actors().filter('traffic.traffic_light'):
+            tl.set_state(carla.TrafficLightState.Green)
+            tl.freeze(True)
+
+        # ---- Collision sensor ---------------------------------------- #
+        self._collision_events = []
+        collision_bp = bp_lib.find('sensor.other.collision')
+        self._collision_sensor = self.world.spawn_actor(
+            collision_bp, carla.Transform(), attach_to=self.vehicle)
+        self._collision_sensor.listen(self._on_collision)
+
+        # ---- Sidecar file state -------------------------------------- #
+        self._sim_dir   = None
+        self._extra_fh  = None
+
+        # ---- Pygame + camera (skip in headless mode) ----------------------- #
         self.display = pygame_init()
-        self.camera_manager = CameraManager(self.world, self.vehicle)
+        if _has_display():
+            self.camera_manager = CameraManager(self.world, self.vehicle)
+        else:
+            self.camera_manager = None
+            print("[CarlaMPCDynamics] Headless mode — camera window disabled.")
 
         # Cache the CARLA map for waypoint queries
         self._carla_map = self.world.get_map()
+
+    # ------------------------------------------------------------------ #
+    #  Sidecar / collision helpers                                        #
+    # ------------------------------------------------------------------ #
+
+    def set_sim_dir(self, sim_dir: str):
+        """Called by plant_runner at the start of each batch."""
+        self._sim_dir = sim_dir if sim_dir.endswith('/') else sim_dir + '/'
+        # Open a fresh sidecar file for this batch (one file per batch dir).
+        if self._extra_fh is not None:
+            try:
+                self._extra_fh.close()
+            except Exception:
+                pass
+        try:
+            self._extra_fh = open(
+                os.path.join(self._sim_dir, 'carla_extra.jsonl'), 'w', buffering=1)
+        except OSError:
+            self._extra_fh = None
+
+    def _on_collision(self, event):
+        """CARLA collision sensor callback."""
+        impulse = event.normal_impulse
+        intensity = math.sqrt(impulse.x**2 + impulse.y**2 + impulse.z**2)
+        self._collision_events.append({
+            'other': event.other_actor.type_id,
+            'intensity': round(intensity, 2),
+        })
+
+    def _write_extra(self, tf: float, x: np.ndarray):
+        """Append one JSON record (NPC positions + collisions) to the sidecar."""
+        if self._extra_fh is None:
+            return
+        npc_data = []
+        for actor in self.world.get_actors():
+            if actor.id == self.vehicle.id:
+                continue
+            if not actor.type_id.startswith('vehicle.'):
+                continue
+            loc = actor.get_transform().location
+            npc_data.append({'id': actor.id,
+                             'x': round(loc.x, 2),
+                             'y': round(loc.y, 2)})
+        col_events = self._collision_events[:]
+        self._collision_events.clear()
+        record = {
+            't':         round(tf, 3),
+            'ego_x':     round(float(x[0, 0]), 2),
+            'ego_y':     round(float(x[1, 0]), 2),
+            'npcs':      npc_data,
+            'collision': col_events[0] if col_events else None,
+        }
+        try:
+            self._extra_fh.write(json.dumps(record) + '\n')
+        except OSError:
+            pass
 
     # ------------------------------------------------------------------ #
     #  Exogenous input: dense waypoints                                   #
     # ------------------------------------------------------------------ #
 
     def get_exogenous_input(self, t):
-        """Return N_w dense waypoints as w ∈ ℝ^{2·N_w} column vector."""
+        """Return waypoints (+ optional obstacle data) as w column vector.
+
+        Layout:
+          w[0 .. 2*N_w - 1]                     = waypoints  (wx1, wy1, …)
+          w[2*N_w + 5*i + 0..4]  (if n_obs > 0) = obstacle i (x, y, vx, vy, radius)
+        Sentinel for empty obstacle slot: x = 1e6, y = 1e6, vx = vy = radius = 0.
+
+        Waypoints that fall inside the safety exclusion zone of any in-lane
+        obstacle are replaced by the last safe waypoint, so the MPC has a
+        collision-free reference trajectory even when an obstacle blocks the road.
+        """
         transform = self.vehicle.get_transform()
         wp = self._carla_map.get_waypoint(transform.location)
         waypoints = []
@@ -178,43 +280,198 @@ class CarlaMPCDynamics(Dynamics):
             wp = nxt[0]
             waypoints.append((wp.transform.location.x, wp.transform.location.y))
 
-        # Pack [wx1, wy1, wx2, wy2, …]
-        w = np.zeros((2 * self.n_wp, 1), dtype=float)
+        # ---- Filter blocked waypoints --------------------------------- #
+        # Fetch in-lane obstacles (same filtering as in _get_nearby_obstacles).
+        # Any waypoint whose distance to an obstacle centroid is less than
+        # ego_radius + obs_radius + safe_margin is replaced by the last
+        # safe waypoint, keeping the reference path out of blocked zones.
+        if self.n_obs > 0:
+            mpc_opts   = self.config["system_parameters"]["mpc_options"]
+            weights    = mpc_opts.get("cost_weights", {})
+            ego_r      = weights.get("ego_radius",  2.5)
+            safe_margin= weights.get("safe_margin",  1.5)
+            obs_data   = self._get_nearby_obstacles()   # already lateral-filtered
+
+            if obs_data:
+                last_safe = None
+                truncated = False
+                for i, (wx, wy) in enumerate(waypoints):
+                    if truncated:
+                        # All waypoints after the first blocked one are
+                        # replaced, so MPC sees no path beyond the obstacle.
+                        if last_safe is not None:
+                            waypoints[i] = last_safe
+                        continue
+                    blocked = False
+                    for ox, oy, _ovx, _ovy, obs_r in obs_data:
+                        r_safe = ego_r + obs_r + safe_margin
+                        if math.sqrt((wx - ox)**2 + (wy - oy)**2) < r_safe:
+                            blocked = True
+                            break
+                    if blocked:
+                        truncated = True
+                        if last_safe is not None:
+                            waypoints[i] = last_safe
+                    else:
+                        last_safe = (wx, wy)
+
+        dim = 2 * self.n_wp + 5 * self.n_obs
+        w = np.zeros((dim, 1), dtype=float)
+
+        # Pack waypoints
         for i, (wx, wy) in enumerate(waypoints):
             w[2 * i]     = wx
             w[2 * i + 1] = wy
+
+        # Pack obstacles (if configured)
+        if self.n_obs > 0:
+            obs_data = self._get_nearby_obstacles()
+            offset = 2 * self.n_wp
+            for i in range(self.n_obs):
+                if i < len(obs_data):
+                    ox, oy, ovx, ovy, r = obs_data[i]
+                    w[offset + 5 * i + 0] = ox
+                    w[offset + 5 * i + 1] = oy
+                    w[offset + 5 * i + 2] = ovx
+                    w[offset + 5 * i + 3] = ovy
+                    w[offset + 5 * i + 4] = r
+                else:
+                    # Sentinel: no obstacle in this slot
+                    w[offset + 5 * i + 0] = 1e6
+                    w[offset + 5 * i + 1] = 1e6
+
         return w
+
+    # ------------------------------------------------------------------ #
+    #  Obstacle detection                                                 #
+    # ------------------------------------------------------------------ #
+
+    def _get_nearby_obstacles(self):
+        """Return up to N_obs closest dynamic actors within detection_radius.
+
+        Only includes obstacles whose lateral offset from the ego's forward
+        direction is within ~2.5 m (roughly one lane width), so adjacent-lane
+        traffic is filtered out.
+
+        Returns list of (x, y, vx, vy, bounding_radius) tuples sorted by
+        ascending distance to the ego vehicle.
+        """
+        ego_tf  = self.vehicle.get_transform()
+        ego_loc = ego_tf.location
+        ego_yaw = math.radians(ego_tf.rotation.yaw)
+        ego_id  = self.vehicle.id
+
+        # Unit vectors: forward and rightward
+        fwd_x =  math.cos(ego_yaw)
+        fwd_y =  math.sin(ego_yaw)
+
+        LATERAL_FILTER = 2.5  # metres — discard obstacles farther sideways
+
+        candidates = []
+        for actor in self.world.get_actors():
+            if actor.id == ego_id:
+                continue
+            if not (actor.type_id.startswith('vehicle.') or
+                    actor.type_id.startswith('walker.')):
+                continue
+
+            loc  = actor.get_transform().location
+            dx   = loc.x - ego_loc.x
+            dy   = loc.y - ego_loc.y
+            dist = math.sqrt(dx * dx + dy * dy)
+            if dist > self.detection_radius:
+                continue
+
+            # Lateral offset relative to ego heading (cross-product magnitude)
+            lat_offset = abs(-dx * fwd_y + dy * fwd_x)
+            if lat_offset > LATERAL_FILTER:
+                continue  # skip adjacent-lane traffic
+
+            vel  = actor.get_velocity()
+            ext  = actor.bounding_box.extent
+            # Top-down bounding circle radius
+            radius = math.sqrt(ext.x ** 2 + ext.y ** 2)
+
+            candidates.append((dist, loc.x, loc.y, vel.x, vel.y, radius))
+
+        candidates.sort(key=lambda c: c[0])
+        return [(ox, oy, ovx, ovy, r)
+                for (_, ox, oy, ovx, ovy, r) in candidates[:self.n_obs]]
+
+    # ------------------------------------------------------------------ #
+    #  Visualization                                                       #
+    # ------------------------------------------------------------------ #
+
+    def _draw_trajectory(self, x0, metadata, w):
+        """Draw waypoints (blue), MPC predicted trajectory (red), and
+        detected obstacles (orange) as 3D CARLA world debug primitives."""
+        if self.world is None:
+            return
+        debug = self.world.debug
+        ego_loc = self.vehicle.get_location()
+        z = ego_loc.z + 0.5  # slightly above ground to avoid z-fighting
+        life_time = max(0.1, self.time_step + 0.05)
+
+        # 1. Waypoints — blue dots (first 2*n_wp entries of w)
+        for i in range(self.n_wp):
+            try:
+                wx = float(w[2 * i])
+                wy = float(w[2 * i + 1])
+            except (IndexError, TypeError):
+                break
+            debug.draw_point(
+                carla.Location(x=wx, y=wy, z=z),
+                size=0.1,
+                color=carla.Color(0, 128, 255),
+                life_time=life_time,
+            )
+
+        # 2. MPC predicted trajectory — red dots from metadata
+        if metadata and isinstance(metadata, dict):
+            tx = metadata.get("traj_x")
+            ty = metadata.get("traj_y")
+            if tx is not None and ty is not None:
+                for i in range(len(tx)):
+                    debug.draw_point(
+                        carla.Location(x=float(tx[i]), y=float(ty[i]), z=z),
+                        size=0.12,
+                        color=carla.Color(255, 0, 0),
+                        life_time=life_time,
+                    )
+
+        # 3. Detected obstacles — orange center + radius ring
+        if self.n_obs > 0:
+            offset = 2 * self.n_wp
+            for i in range(self.n_obs):
+                try:
+                    ox = float(w[offset + 5 * i + 0])
+                    oy = float(w[offset + 5 * i + 1])
+                except (IndexError, TypeError):
+                    break
+                if ox > 1e5:  # sentinel — empty slot
+                    continue
+                r = float(w[offset + 5 * i + 4])
+                # Center dot
+                debug.draw_point(
+                    carla.Location(x=ox, y=oy, z=z),
+                    size=0.2,
+                    color=carla.Color(255, 165, 0),
+                    life_time=life_time,
+                )
+                # Radius ring (12 points)
+                for j in range(12):
+                    theta = j * math.pi / 6
+                    debug.draw_point(
+                        carla.Location(x=ox + r * math.cos(theta),
+                                       y=oy + r * math.sin(theta), z=z),
+                        size=0.05,
+                        color=carla.Color(255, 165, 0),
+                        life_time=life_time,
+                    )
 
     # ------------------------------------------------------------------ #
     #  State evolution                                                    #
     # ------------------------------------------------------------------ #
-
-    def _draw_trajectory(self, x, metadata, waypoints):
-        """Draw waypoints (blue) and MPC trajectory (red) in the 3D CARLA world."""
-        if self.world is None: return
-        
-        debug = self.world.debug
-        ego_loc = self.vehicle.get_location()
-        z = ego_loc.z + 0.5  # Slightly above ground to avoid z-fighting
-        
-        life_time = max(0.1, self.time_step + 0.05) # ensure it lasts until next frame
-        
-        # 1. Draw waypoints (blue dots)
-        if waypoints is not None:
-            # waypoints is [wx1, wy1, wx2, wy2, ...]
-            for i in range(len(waypoints) // 2):
-                wx = float(waypoints[2*i])
-                wy = float(waypoints[2*i+1])
-                debug.draw_point(carla.Location(x=wx, y=wy, z=z), size=0.1, color=carla.Color(0, 1, 255), life_time=life_time)
-        
-        # 2. Draw MPC planned trajectory (red dots)
-        if metadata and "traj_x" in metadata and "traj_y" in metadata:
-            tx = metadata["traj_x"]
-            ty = metadata["traj_y"]
-            for i in range(len(tx)):
-                px = float(tx[i])
-                py = float(ty[i])
-                debug.draw_point(carla.Location(x=px, y=py, z=z), size=0.1, color=carla.Color(255, 0, 0), life_time=life_time)
 
     def evolve_state(self, t0, x0, u, w, tf, metadata=None):
         """Apply control u = (a, delta) to CARLA and return x = (px, py, psi, v)."""
@@ -230,6 +487,7 @@ class CarlaMPCDynamics(Dynamics):
             brake    = min(-accel, 1.0)  # normalise by |min_accel|
 
         # Map steering angle → CARLA steer in [-1, 1]
+        # CARLA expects steer in [-1, 1]; max physical angle ≈ 0.7 rad
         steer = max(-1.0, min(1.0, delta))
 
         steps = max(1, math.floor((tf - t0) / self.time_step))
@@ -241,14 +499,14 @@ class CarlaMPCDynamics(Dynamics):
                 brake=brake
             ))
 
-            # Render camera view
-            if self.camera_manager.surface is not None:
-                self.display.blit(self.camera_manager.surface, (0, 0))
-            
-            # Draw waypoints and trajectory overlay
-            self._draw_trajectory(x0, metadata, w)
-            
-            pygame.display.flip()
+            # Render camera view (skip when headless)
+            if self.display is not None and self.camera_manager is not None:
+                if self.camera_manager.surface is not None:
+                    self.display.blit(self.camera_manager.surface, (0, 0))
+                self._draw_trajectory(x0, metadata, w.flatten())
+                pygame.display.flip()
+            else:
+                self._draw_trajectory(x0, metadata, w.flatten())
 
             # Logging
             vel = self.vehicle.get_velocity()
@@ -267,14 +525,12 @@ class CarlaMPCDynamics(Dynamics):
         transform = self.vehicle.get_transform()
         velocity  = self.vehicle.get_velocity()
         yaw_rad   = math.radians(transform.rotation.yaw)
-        
-        # Transform global velocity to local (body) frame
-        v_x_global = velocity.x
-        v_y_global = velocity.y
-        v_x_local = v_x_global * math.cos(yaw_rad) + v_y_global * math.sin(yaw_rad)
-        v_y_local = -v_x_global * math.sin(yaw_rad) + v_y_global * math.cos(yaw_rad)
-        
-        # Read angular velocity (CARLA returns deg/s)
+
+        # Project global velocity into body frame
+        v_x_local = velocity.x * math.cos(yaw_rad) + velocity.y * math.sin(yaw_rad)
+        v_y_local = -velocity.x * math.sin(yaw_rad) + velocity.y * math.cos(yaw_rad)
+
+        # Angular velocity: CARLA returns deg/s, convert to rad/s
         ang_vel = self.vehicle.get_angular_velocity()
         r_rad_s = math.radians(ang_vel.z)
 
@@ -295,6 +551,7 @@ class CarlaMPCDynamics(Dynamics):
                 [r_rad_s],
             ], dtype=float)
 
+        self._write_extra(tf, x)
         return tf, x
 
     # ------------------------------------------------------------------ #
@@ -303,13 +560,26 @@ class CarlaMPCDynamics(Dynamics):
 
     def teardown(self):
         print("[CarlaMPCDynamics] Tearing down …")
+        # Close sidecar file
+        if getattr(self, '_extra_fh', None) is not None:
+            try:
+                self._extra_fh.close()
+            except Exception:
+                pass
+            self._extra_fh = None
+        # Stop and destroy collision sensor first (stops the sensor stream)
+        if getattr(self, '_collision_sensor', None) is not None:
+            try:
+                self._collision_sensor.stop()
+                self._collision_sensor.destroy()
+                print("[CarlaMPCDynamics] Collision sensor stopped and destroyed.")
+            except Exception as e:
+                print(f"[CarlaMPCDynamics] Warning: collision sensor cleanup: {e}")
+            self._collision_sensor = None
         try:
             for ctrl in getattr(self, 'npc_walker_controllers', []):
                 try: ctrl.stop()
                 except Exception: pass
-
-            if hasattr(self, 'world') and self.world is not None:
-                self.world.tick()
 
             if hasattr(self, 'camera_manager') and self.camera_manager is not None:
                 self.camera_manager.destroy()
@@ -338,7 +608,13 @@ class CarlaMPCDynamics(Dynamics):
             if hasattr(self, 'traffic_manager'):
                 self.traffic_manager.set_synchronous_mode(False)
 
-            pygame.quit()
+            if _has_display():
+                pygame.quit()
+
+            # Give CARLA time to flush sensor streams and settle before the
+            # next session connects (avoids "Invalid session: no stream" spam)
+            import time as _time; _time.sleep(2.0)
+            print("[CarlaMPCDynamics] Teardown complete.")
         except Exception as e:
             print(f"[CarlaMPCDynamics] cleanup error: {e}")
 
@@ -350,7 +626,14 @@ class CarlaMPCDynamics(Dynamics):
         if count == 0:
             return []
         vehicle_bps = sorted(bp_lib.filter('vehicle.*'), key=lambda bp: bp.id)
+
+        # Sort available spawn points by distance to ego so NPCs spawn
+        # at the nearest locations, creating meaningful proximate traffic.
+        ego_loc = self.vehicle.get_location()
         available = [sp for i, sp in enumerate(spawn_points) if i != ego_idx]
+        available.sort(
+            key=lambda sp: (sp.location.x - ego_loc.x) ** 2 + (sp.location.y - ego_loc.y) ** 2
+        )
         count = min(count, len(available))
         vehicles = []
         for i in range(count):

--- a/resources/sharc/dashboard.py
+++ b/resources/sharc/dashboard.py
@@ -167,6 +167,86 @@ def extract_steps(raw: dict):
     return t_s, x_s, u_s, delays
 
 
+def load_carla_extra(sim_dir: str):
+    """
+    Aggregate NPC trajectory data and collision events from all
+    ``carla_extra.jsonl`` sidecar files produced by CarlaMPCDynamics.
+
+    Looks in *sim_dir* itself and in any immediate sub-directories
+    (batch dirs), so both serial and parallel modes are handled.
+
+    Returns
+    -------
+    npc_tracks : dict  id → {"label": str, "xs": list, "ys": list}
+    collisions  : list of dicts  {"t", "ego_x", "ego_y", "other", "intensity"}
+    """
+    # Gather candidate files (sim_dir first, then sorted sub-dirs so
+    # batches appear in chronological order).
+    files = []
+    top = os.path.join(sim_dir, 'carla_extra.jsonl')
+    if os.path.isfile(top):
+        files.append(top)
+    try:
+        for entry in sorted(os.listdir(sim_dir)):
+            sub = os.path.join(sim_dir, entry, 'carla_extra.jsonl')
+            if os.path.isfile(sub):
+                files.append(sub)
+    except OSError:
+        pass
+
+    npc_tracks = {}   # actor_id  → {"label", "xs", "ys"}
+    collisions  = []
+    npc_counter = 0
+
+    for fpath in files:
+        try:
+            with open(fpath, 'r') as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rec = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    for npc in rec.get('npcs', []):
+                        nid = npc['id']
+                        if nid not in npc_tracks:
+                            npc_counter += 1
+                            npc_tracks[nid] = {
+                                'label': f'NPC {npc_counter}',
+                                'xs': [], 'ys': [],
+                            }
+                        npc_tracks[nid]['xs'].append(npc['x'])
+                        npc_tracks[nid]['ys'].append(npc['y'])
+                    col = rec.get('collision')
+                    if col:
+                        collisions.append({
+                            't':         rec.get('t', 0),
+                            'ego_x':     rec.get('ego_x', 0),
+                            'ego_y':     rec.get('ego_y', 0),
+                            'other':     col.get('other', 'unknown'),
+                            'intensity': col.get('intensity', 0),
+                        })
+        except OSError:
+            pass
+
+    return npc_tracks, collisions
+
+
+# NPC colour palette — warm/vivid tones that stand out on the dark background
+_NPC_COLORS = [
+    '#fab387',  # peach
+    '#f9e2af',  # yellow
+    '#a6e3a1',  # green
+    '#94e2d5',  # teal
+    '#74c7ec',  # sky
+    '#cba6f7',  # mauve
+    '#f2cdcd',  # flamingo
+    '#eba0ac',  # maroon
+]
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Figure setup
 # ─────────────────────────────────────────────────────────────────────────────
@@ -260,14 +340,17 @@ class Dashboard:
                 pass
             self._status_text = None
 
-    def _update_title(self, n_steps: int, n_miss: int, sim_dir: str):
+    def _update_title(self, n_steps: int, n_miss: int, n_collisions: int, sim_dir: str):
         name  = os.path.basename(sim_dir)
-        T     = self._config_cache.get("sample_time", "?")
-        label = self._config_cache.get("label", "")
+        T     = self._config_cache.get('sample_time', '?')
+        label = self._config_cache.get('label', '')
+        collision_tag = f'  \u26a0 {n_collisions} COLLISION(S)' if n_collisions else ''
         self.fig.suptitle(
-            f"SHARC Live Dashboard  |  {label}  |  T = {T} s  "
-            f"|  step {n_steps}  |  deadline misses: {n_miss}",
-            color=_TEXT_CLR, fontsize=11, fontweight="bold",
+            f'SHARC Live Dashboard  |  {label}  |  T = {T} s  '
+            f'|  step {n_steps}  |  deadline misses: {n_miss}'
+            f'{collision_tag}',
+            color='#f38ba8' if n_collisions else _TEXT_CLR,
+            fontsize=11, fontweight='bold',
             x=0.5, y=0.97,
         )
 
@@ -354,12 +437,18 @@ class Dashboard:
                     except (json.JSONDecodeError, OSError):
                         cfg = {}
             sp  = cfg.get("system_parameters", {})
+            mpc_o = sp.get("mpc_options", {})
+            lims  = mpc_o.get("input_limits", {})
             self._config_cache = {
                 "sample_time": sp.get("sample_time", 0.1),
                 "x_names":     sp.get("x_names", ["x","y","yaw","speed","wp_x","wp_y"]),
                 "u_names":     sp.get("u_names", ["throttle","steer","brake"]),
                 "target_speed":sp.get("target_speed", None),
                 "label":       cfg.get("label", ""),
+                "mpc_opts": {
+                    "max_accel": lims.get("max_accel",  1.0),
+                    "min_accel": lims.get("min_accel", -3.0),
+                },
             }
 
         # ── 4. Extract per-step data ─────────────────────────────────────────
@@ -388,16 +477,32 @@ class Dashboard:
         wp_x  = x[:, 4] if x.shape[1] > 4 else None
         wp_y  = x[:, 5] if x.shape[1] > 5 else None
 
-        # Control columns resolved by u_names
+        # Control columns resolved by u_names.
+        # Supports two conventions:
+        #   (a) PID-style:  u = [throttle, steer, brake]     (CARLA commands, [0,1])
+        #   (b) MPC-style:  u = [acceleration, steering_angle] (physical units)
+        #       → throttle = max(a, 0) / max_accel,  brake = max(-a, 0) / |min_accel|
         def _col(name, fallback):
             try:
                 return u[:, u_names.index(name)]
             except (ValueError, IndexError):
                 return u[:, fallback] if u.shape[1] > fallback else np.zeros(n_steps)
 
-        throttle = _col("throttle", 0)
-        steer    = _col("steer",    1)
-        brake    = _col("brake",    2)
+        mpc_opts   = (self._config_cache.get("mpc_opts") or {})
+        _is_mpc    = ("acceleration" in u_names or "steering_angle" in u_names)
+
+        if _is_mpc:
+            accel = _col("acceleration",   0)
+            delta = _col("steering_angle", 1)
+            _max_a = mpc_opts.get("max_accel", 1.0)
+            _min_a = mpc_opts.get("min_accel", -3.0)
+            throttle = np.clip( accel / max(_max_a,  1e-6), 0.0, 1.0)
+            brake    = np.clip(-accel / max(-_min_a, 1e-6), 0.0, 1.0)
+            steer    = np.clip(delta, -1.0, 1.0)
+        else:
+            throttle = _col("throttle", 0)
+            steer    = _col("steer",    1)
+            brake    = _col("brake",    2)
 
         # Deadline misses
         miss_mask = (delays >= T) if len(delays) else np.zeros(n_steps, bool)
@@ -406,16 +511,72 @@ class Dashboard:
         ax = self.axes
 
         # ── 6. XY Trajectory ───────────────────────────────────────────────
-        ax["xy"].cla()
-        _style_ax(ax["xy"], "Vehicle Trajectory", "X (m)", "Y (m)")
-        ax["xy"].set_aspect("equal", adjustable="datalim")
-        ax["xy"].plot(px, py, color="#89b4fa", linewidth=1.5, label="Path")
-        ax["xy"].plot(px[-1], py[-1], "o", color="#f38ba8",
-                      markersize=7, label="Current")
+        npc_tracks, collisions = load_carla_extra(sim_dir)
+        n_collisions = len(collisions)
+
+        ax['xy'].cla()
+        title_color = '#f38ba8' if n_collisions else _TEXT_CLR
+        title_text  = ('Vehicle Trajectory'
+                       if not n_collisions
+                       else f'Vehicle Trajectory  \u26a0 {n_collisions} COLLISION(S)')
+        _style_ax(ax['xy'], title_text, 'X (m)', 'Y (m)')
+        ax['xy'].title.set_color(title_color)
+        ax['xy'].set_aspect('equal', adjustable='datalim')
+
+        # Ego path — coloured gradient (older = dimmer, newest = bright)
+        if len(px) > 1:
+            from matplotlib.collections import LineCollection
+            points  = np.array([px, py]).T.reshape(-1, 1, 2)
+            segs    = np.concatenate([points[:-1], points[1:]], axis=1)
+            alphas  = np.linspace(0.15, 1.0, len(segs))
+            for seg, a in zip(segs, alphas):
+                ax['xy'].plot(seg[:, 0], seg[:, 1],
+                              color='#89b4fa', linewidth=2.0, alpha=float(a),
+                              solid_capstyle='round')
+        elif len(px) == 1:
+            ax['xy'].plot(px, py, 'o', color='#89b4fa', markersize=5)
+
+        # Waypoints
         if wp_x is not None and wp_y is not None:
-            ax["xy"].scatter(wp_x, wp_y, c="#a6e3a1", s=10,
-                             alpha=0.4, zorder=3, label="Waypoints")
-        ax["xy"].legend(fontsize=7, facecolor=_DARK_BG, labelcolor=_TEXT_CLR)
+            ax['xy'].scatter(wp_x, wp_y, c='#a6e3a1', s=8,
+                             alpha=0.35, zorder=3, label='Waypoints')
+
+        # NPC trajectories
+        for i, (nid, track) in enumerate(npc_tracks.items()):
+            clr = _NPC_COLORS[i % len(_NPC_COLORS)]
+            xs, ys = track['xs'], track['ys']
+            if len(xs) > 1:
+                ax['xy'].plot(xs, ys, color=clr, linewidth=1.0,
+                              linestyle='--', alpha=0.55, zorder=4)
+            if xs:
+                ax['xy'].plot(xs[-1], ys[-1], 's', color=clr,
+                              markersize=5, alpha=0.9, zorder=5,
+                              label=track['label'])
+
+        # Collision markers
+        for col in collisions:
+            ax['xy'].plot(col['ego_x'], col['ego_y'],
+                          'X', color='#ff2222', markersize=13,
+                          markeredgewidth=2.0, zorder=10)
+            ax['xy'].annotate(
+                f"\u26a0 COLLISION\n"
+                f"{col['other'].split('.')[-1][:16]}\n"
+                f"{col['intensity']:.0f} N·m/s",
+                xy=(col['ego_x'], col['ego_y']),
+                xytext=(8, 8), textcoords='offset points',
+                color='#ff4444', fontsize=6.5,
+                bbox=dict(boxstyle='round,pad=0.3',
+                          facecolor='#2a0000', alpha=0.85,
+                          edgecolor='#ff4444', linewidth=0.8),
+                zorder=11,
+            )
+
+        # Ego current position (on top of everything)
+        ax['xy'].plot(px[-1], py[-1], 'o', color='#f38ba8',
+                      markersize=8, zorder=12, label='Ego')
+
+        ax['xy'].legend(fontsize=7, facecolor=_DARK_BG, labelcolor=_TEXT_CLR,
+                        framealpha=0.8, edgecolor=_GRID_CLR)
 
         # ── 7. Speed ────────────────────────────────────────────────────────
         ax["spd"].cla()
@@ -444,7 +605,10 @@ class Dashboard:
 
         # ── 9. Throttle / Brake ─────────────────────────────────────────────
         ax["tbrk"].cla()
-        _style_ax(ax["tbrk"], "Throttle / Brake", "Time (s)", "Command [0, 1]")
+        if _is_mpc:
+            _style_ax(ax["tbrk"], "Throttle / Brake (derived)", "Time (s)", "Normalised [0, 1]")
+        else:
+            _style_ax(ax["tbrk"], "Throttle / Brake", "Time (s)", "Command [0, 1]")
         ax["tbrk"].set_ylim(-0.05, 1.05)
         ax["tbrk"].plot(t, throttle, color="#a6e3a1",
                          linewidth=1.5, label="Throttle")
@@ -454,13 +618,17 @@ class Dashboard:
 
         # ── 10. Steering ────────────────────────────────────────────────────
         ax["steer"].cla()
-        _style_ax(ax["steer"], "Steering", "Time (s)", "Steer [-1, 1]")
-        ax["steer"].set_ylim(-1.1, 1.1)
+        if _is_mpc:
+            _style_ax(ax["steer"], "Steering Angle", "Time (s)", "δ (rad)")
+            ax["steer"].set_ylim(-0.55, 0.55)
+        else:
+            _style_ax(ax["steer"], "Steering", "Time (s)", "Steer [-1, 1]")
+            ax["steer"].set_ylim(-1.1, 1.1)
         ax["steer"].plot(t, steer, color="#fab387", linewidth=1.5)
         ax["steer"].axhline(0, color=_GRID_CLR, linewidth=0.8)
 
         # ── 11. Title ────────────────────────────────────────────────────────
-        self._update_title(n_steps, n_miss, sim_dir)
+        self._update_title(n_steps, n_miss, n_collisions, sim_dir)
 
         self.fig.canvas.draw_idle()
 
@@ -514,6 +682,12 @@ def main():
         default=1000,
         help="Plot refresh interval in milliseconds (default: 1000)",
     )
+    parser.add_argument(
+        "--save",
+        action="store_true",
+        help="Render the final dashboard and save it to the experiment directory "
+             "without opening a window (works headless).",
+    )
     args = parser.parse_args()
 
     example_dir = os.path.abspath(args.example_dir)
@@ -521,7 +695,7 @@ def main():
         print(f"[dashboard] ERROR: directory not found: {example_dir}", file=sys.stderr)
         sys.exit(1)
 
-    if not _HAS_DISPLAY:
+    if not _HAS_DISPLAY and not args.save:
         print("[dashboard] No display available (headless). Dashboard disabled.")
         sys.exit(0)
 
@@ -539,7 +713,12 @@ def main():
         sim_dir_override=args.sim_dir,
         interval_ms=args.interval,
     )
-    dash.run()
+
+    if args.save:
+        dash.update(0)          # render one frame from the completed experiment
+        dash.save_final_image()
+    else:
+        dash.run()
 
 
 if __name__ == "__main__":

--- a/resources/sharc/dynamics_base.py
+++ b/resources/sharc/dynamics_base.py
@@ -20,6 +20,15 @@ class Dynamics(ABC):
     def setup_system(self):
       pass
 
+    def set_sim_dir(self, sim_dir: str):
+      """Called by plant_runner before each simulation batch starts.
+
+      Subclasses can override this to receive the current batch simulation
+      directory (e.g. to write sidecar data files alongside experiment data).
+      The default implementation is a no-op.
+      """
+      pass
+
     def teardown(self):
       """Release resources acquired in setup_system().
 

--- a/resources/sharc/plant_runner.py
+++ b/resources/sharc/plant_runner.py
@@ -54,6 +54,12 @@ def run(sim_dir: str, config_data: dict, dynamics: Dynamics, controller_interfac
                                       x0=x0, 
                                       pending_computation_prior=pending_computation0)
     
+    # Notify dynamics of the current simulation directory so it can write
+    # sidecar files (e.g. NPC trajectories, collision events) alongside the
+    # experiment data.  Uses duck-typing so non-CARLA dynamics are unaffected.
+    if hasattr(dynamics, 'set_sim_dir'):
+        dynamics.set_sim_dir(sim_dir)
+
     controller_interface.post_simulator_running() # Post the simulator status for the controller to access.
 
     simulation_time_steps = list(range(first_time_index, first_time_index + n_time_steps))

--- a/run_carla_sharc.sh
+++ b/run_carla_sharc.sh
@@ -16,7 +16,7 @@ fi
 
 # Configuration
 IMAGE_NAME="carla-sharc"
-CONTAINER_NAME="carla-sharc"
+CONTAINER_NAME="carla-sharc-yasin5"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Colors
@@ -107,5 +107,7 @@ docker run -it \
     -v /tmp/.X11-unix:/tmp/.X11-unix \
     -v "$SCRIPT_DIR/resources":/home/workspace/sharc/resources \
     -v "$SCRIPT_DIR/examples":/home/workspace/sharc/examples \
+    -v "$SCRIPT_DIR/run_offscreen_experiment.sh":/home/workspace/sharc/run_offscreen_experiment.sh \
+    -v "$SCRIPT_DIR/experiment_run.json":/home/workspace/sharc/experiment_run.json \
     "$IMAGE_NAME" 
 

--- a/run_offscreen_experiment.sh
+++ b/run_offscreen_experiment.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# CARLA + SHARC Headless Experiment Runner
+# Run from the HOST machine — no monitor or X display required.
+# Usage: ./run_offscreen_experiment.sh [--example NAME] [--config FILE]
+#        [--container NAME] [--user NAME] [--timeout SECS] [--log FILE]
+
+set -euo pipefail
+
+CONTAINER="carla-sharc-yasin5"
+CONTAINER_USER="admin"
+EXAMPLE_NAME="MPC_example"
+CONFIG_NAME="obstacle_constraint.json"
+CARLA_PORT=2000
+TIMEOUT=180
+LOG_FILE=""
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --example)   EXAMPLE_NAME="$2";   shift 2 ;;
+        --config)    CONFIG_NAME="$2";    shift 2 ;;
+        --container) CONTAINER="$2";      shift 2 ;;
+        --user)      CONTAINER_USER="$2"; shift 2 ;;
+        --timeout)   TIMEOUT="$2";        shift 2 ;;
+        --log)       LOG_FILE="$2";       shift 2 ;;
+        -h|--help)
+            sed -n '2,5p' "$0" | sed 's/^# \?//'
+            exit 0 ;;
+        *) die "Unknown option: $1" ;;
+    esac
+done
+
+docker inspect "$CONTAINER" --format '{{.State.Running}}' 2>/dev/null | grep -q true \
+    || die "Container '$CONTAINER' is not running. Start it with: docker start $CONTAINER"
+
+[[ -n "$LOG_FILE" ]] && exec > >(tee -a "$LOG_FILE") 2>&1
+
+echo "==> Container: $CONTAINER (user: $CONTAINER_USER)"
+echo "==> Example:   $EXAMPLE_NAME / $CONFIG_NAME"
+echo ""
+
+docker exec -i \
+    -u "$CONTAINER_USER" \
+    -e DISPLAY= \
+    -e SDL_VIDEODRIVER=offscreen \
+    -e _EXP_EXAMPLE="$EXAMPLE_NAME" \
+    -e _EXP_CONFIG="$CONFIG_NAME" \
+    -e _EXP_PORT="$CARLA_PORT" \
+    -e _EXP_TIMEOUT="$TIMEOUT" \
+    "$CONTAINER" bash -s <<'CONTAINER_SCRIPT'
+set -euo pipefail
+
+CARLA_ROOT=/home/workspace/carla_0.9.16
+EXAMPLE_DIR="/home/workspace/sharc/examples/${_EXP_EXAMPLE}"
+CARLA_LOG="${EXAMPLE_DIR}/carla_server.log"
+
+source /opt/conda/etc/profile.d/conda.sh 2>/dev/null || true
+conda activate carla 2>/dev/null || true
+
+echo "Running as: $(whoami)"
+
+# Kill stale CARLA
+pkill -f CarlaUE4 2>/dev/null || true
+sleep 2
+
+# [1/3] Start CARLA
+echo ""
+echo "=== [1/3] Starting CARLA (headless, -nullrhi) ==="
+"$CARLA_ROOT/CarlaUE4.sh" -nullrhi -RenderOffScreen -nosound \
+    -carla-rpc-port="${_EXP_PORT}" > "$CARLA_LOG" 2>&1 &
+CARLA_PID=$!
+echo "CARLA PID: $CARLA_PID | log: $CARLA_LOG"
+
+trap 'echo "Stopping CARLA..."; kill "$CARLA_PID" 2>/dev/null; pkill -f CarlaUE4 2>/dev/null; wait "$CARLA_PID" 2>/dev/null' EXIT INT TERM
+
+# [2/3] Wait for RPC port
+echo ""
+echo "=== [2/3] Waiting for CARLA on port ${_EXP_PORT} (timeout ${_EXP_TIMEOUT}s) ==="
+elapsed=0
+until python3 -c "import socket; s=socket.socket(); s.settimeout(1); s.connect(('localhost',${_EXP_PORT})); s.close()" 2>/dev/null; do
+    kill -0 "$CARLA_PID" 2>/dev/null || { echo "ERROR: CARLA died. Log:"; tail -40 "$CARLA_LOG"; exit 1; }
+    [[ $elapsed -lt $_EXP_TIMEOUT ]] || { echo "ERROR: Timeout after ${_EXP_TIMEOUT}s. Log:"; tail -40 "$CARLA_LOG"; exit 1; }
+    sleep 3; elapsed=$((elapsed+3)); echo "  ${elapsed}s..."
+done
+echo "CARLA ready (${elapsed}s)"
+
+# [3/3] Run SHARC
+echo ""
+echo "=== [3/3] Running SHARC: ${_EXP_CONFIG} ==="
+cd "$EXAMPLE_DIR"
+sharc --config_filename "${_EXP_CONFIG}"
+
+echo ""
+echo "=== Saving dashboard image ==="
+python3 -m sharc.dashboard --save "$EXAMPLE_DIR"
+
+echo ""
+echo "=== DONE ==="
+[[ -L latest ]] && echo "Results: $EXAMPLE_DIR/$(readlink latest)"
+CONTAINER_SCRIPT


### PR DESCRIPTION
- Add run_offscreen_experiment.sh: single host-side script that launches CARLA with -nullrhi/-RenderOffScreen, runs SHARC, and saves a final dashboard PNG via docker exec heredoc pattern
- Add --save flag to dashboard.py for headless PNG generation using Agg backend, no display required
- Add headless guards to carla_dynamics.py and carla_mpc_dynamics.py: CameraManager optional, pygame skipped without display, 60s client timeout
- Add set_sim_dir hook to dynamics_base.py; call it in plant_runner.py so dynamics can write per-sim output files such as carla_extra.jsonl
- Fix CMakeLists.txt: Threads::Threads pthread linker, TNIEQ variable for obstacle constraints, add CarlaConstraintMPC/ObstacleMPC/KinematicMPPI sources
- Add new controller headers and sources: CarlaConstraintMPCController, CarlaObstacleMPCController, CarlaKinematicMPPIController
- Add simulation configs: obstacle_constraint.json, obstacle_barrier.json, obstacle_progress.json
- Fix entrypoint.sh: repair bind-mount ownership at container startup
- Update run_carla_sharc.sh: container name, bind mounts for runner script
- Add experiment_run.json: example JSON config for --json mode
- Document headless workflow in README.carla-sharc.md